### PR TITLE
Refactor kinematic state to use KinematicPoint coordinate abstraction

### DIFF
--- a/components/Visualization.tsx
+++ b/components/Visualization.tsx
@@ -54,8 +54,8 @@ export function BikeVisualization({
       Math.max(0, Math.min(stateIndex, analysisResults.states.length - 1))
     ];
 
-  const rearAxleWorld = state.rearAxlePosition;
-  const frontAxleWorld = state.frontAxlePosition;
+  const rearAxleWorld = state.rearAxle.world;
+  const frontAxleWorld = state.frontAxle.world;
 
   // Calculate canvas bounds
   const padding = 50;
@@ -143,8 +143,7 @@ export function AnimationView({
   animationSpeed,
   ...props
 }: AnimationViewProps) {
-  const axlePath = props.analysisResults.states.map((s) => s.rearAxlePosition);
-  console.log("Axle path:", axlePath);
+  const axlePath = props.analysisResults.states.map((s) => s.rearAxle.world);
   const [animProgress, setAnimProgress] = React.useState(
     initialTravelPercentage,
   );

--- a/components/visualization/AxlePath.tsx
+++ b/components/visualization/AxlePath.tsx
@@ -12,15 +12,13 @@ export const AxlePath = ({
 
   const { toCanvas } = conversion;
   const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxlePosition,
+    state.rearAxle.world,
     state.pitchAngleDegrees,
   );
-  console.log("Axle path input:", axlePath);
-  const axlePathWorld = axlePath
-    .map((p) => Point2D.add(state.bbPosition, p))
-    .map(applyPitchRotation);
-  console.log("Axle path world:", axlePathWorld);
-  const points = axlePathWorld.map(toCanvas);
+  const points = axlePath
+    .map((p) => Point2D.add(state.bb.world, p))
+    .map(applyPitchRotation)
+    .map(toCanvas);
   return (
     <polyline
       points={pointsToPolylineString(points)}

--- a/components/visualization/CentreOfMass.tsx
+++ b/components/visualization/CentreOfMass.tsx
@@ -9,12 +9,12 @@ export const CentreOfMass = ({
 }: DrawComponentProps) => {
   const { toCanvas } = conversion;
   const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxlePosition,
+    state.rearAxle.world,
     state.pitchAngleDegrees,
   );
-  // TODO: Do we need to add CoM before or after pitch rotation>
+  // CoM is defined relative to BB in world space, then pitch-rotated
   const comRotated = applyPitchRotation(
-    Point2D.add(state.bbPosition, {
+    Point2D.add(state.bb.world, {
       x: geometry.comX,
       y: geometry.comY,
     }),

--- a/components/visualization/CentreOfMass.tsx
+++ b/components/visualization/CentreOfMass.tsx
@@ -1,26 +1,8 @@
-import { getApplyPitchRotation } from "@/lib/kinematics";
 import { DrawComponentProps } from "./types";
-import { Point2D } from "@/lib/types";
 
-export const CentreOfMass = ({
-  state,
-  conversion,
-  geometry,
-}: DrawComponentProps) => {
+export const CentreOfMass = ({ state, conversion }: DrawComponentProps) => {
   const { toCanvas } = conversion;
-  const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxle.world,
-    state.pitchAngleDegrees,
-  );
-  // CoM is defined relative to BB in world space, then pitch-rotated
-  const comRotated = applyPitchRotation(
-    Point2D.add(state.bb.world, {
-      x: geometry.comX,
-      y: geometry.comY,
-    }),
-  );
-
-  const comCanvas = toCanvas(comRotated);
+  const comCanvas = toCanvas(state.centreOfMass.wheelsOnGround);
 
   return (
     <circle

--- a/components/visualization/Drivetrain.tsx
+++ b/components/visualization/Drivetrain.tsx
@@ -8,17 +8,17 @@ export const Drivetrain = ({
   state,
   conversion,
 }: DrawComponentProps) => {
-  const bbPos = state.bbPosition;
+  const bbPos = state.bb.world;
   const scale = conversion.scale;
 
   const { toCanvasX, toCanvasY } = conversion;
 
   const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxlePosition,
+    state.rearAxle.world,
     state.pitchAngleDegrees,
   );
 
-  const rearAxlePosRotated = applyPitchRotation(state.rearAxlePosition);
+  const rearAxlePosRotated = state.rearAxle.wheelsOnGround;
 
   const chainringPos = {
     x: bbPos.x + geometry.chainringOffsetX,

--- a/components/visualization/Drivetrain.tsx
+++ b/components/visualization/Drivetrain.tsx
@@ -1,5 +1,5 @@
 import { sprocketRadius, tangentPoints } from "@/lib/geometry";
-import { getApplyPitchRotation, getIdlerPosition } from "@/lib/kinematics";
+import { getApplyPitchRotation } from "@/lib/kinematics";
 import { IdlerType, Point2D } from "@/lib/types";
 import { DrawComponentProps } from "./types";
 
@@ -8,24 +8,13 @@ export const Drivetrain = ({
   state,
   conversion,
 }: DrawComponentProps) => {
-  const bbPos = state.bb.world;
   const scale = conversion.scale;
-
   const { toCanvasX, toCanvasY } = conversion;
 
-  const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxle.world,
-    state.pitchAngleDegrees,
-  );
+  const chainringRotated = state.chainringCenter.wheelsOnGround;
+  const cogRotated = state.rearAxle.wheelsOnGround;
+  const idlerRotated = state.idler?.wheelsOnGround ?? null;
 
-  const rearAxlePosRotated = state.rearAxle.wheelsOnGround;
-
-  const chainringPos = {
-    x: bbPos.x + geometry.chainringOffsetX,
-    y: bbPos.y + geometry.chainringOffsetY,
-  };
-  const chainringRotated = applyPitchRotation(chainringPos);
-  const cogRotated = rearAxlePosRotated;
   const chainringRadius = sprocketRadius(geometry.chainringTeeth);
   const cogRadius = sprocketRadius(geometry.cogTeeth);
 
@@ -33,42 +22,26 @@ export const Drivetrain = ({
   const cogRadiusScreen = cogRadius * scale;
 
   const chainSegments: { start: Point2D; end: Point2D }[] = [];
-
-  let idlerRotated: Point2D | null = null;
   let idlerRadiusScreen = 0;
 
   if (geometry.idlerType === IdlerType.None) {
-    // Chainring to cog
-    const tangents = tangentPoints(
-      chainringRotated,
-      chainringRadius,
-      cogRotated,
-      cogRadius,
-    );
-    chainSegments.push(tangents);
-  } else {
-    const idlerPos = getIdlerPosition(state, geometry)!;
-    idlerRotated = applyPitchRotation(idlerPos);
-
+    chainSegments.push(tangentPoints(chainringRotated, chainringRadius, cogRotated, cogRadius));
+  } else if (idlerRotated) {
     const idlerRadius = sprocketRadius(geometry.idlerTeeth);
     idlerRadiusScreen = idlerRadius * scale;
-
-    const cogToIdler = tangentPoints(
-      idlerRotated,
-      idlerRadius,
-      cogRotated,
-      cogRadius,
-    );
-    chainSegments.push(cogToIdler);
-
-    const chainringToIdler = tangentPoints(
-      chainringRotated,
-      chainringRadius,
-      idlerRotated,
-      idlerRadius,
-    );
-    chainSegments.push(chainringToIdler);
+    chainSegments.push(tangentPoints(idlerRotated, idlerRadius, cogRotated, cogRadius));
+    chainSegments.push(tangentPoints(chainringRotated, chainringRadius, idlerRotated, idlerRadius));
   }
+
+  // Crank arm: crankAngle is currently always 0 but kept for when kickback is implemented
+  const crankLength = 165.0;
+  const crankAngleRad = state.crankAngle * (Math.PI / 180);
+  const crankEndWorld = {
+    x: state.chainringCenter.world.x + crankLength * Math.cos(crankAngleRad),
+    y: state.chainringCenter.world.y - crankLength * Math.sin(crankAngleRad),
+  };
+  const applyPitchRotation = getApplyPitchRotation(state.rearAxle.world, state.pitchAngleDegrees);
+  const crankEndRotated = applyPitchRotation(crankEndWorld);
 
   return (
     <>
@@ -114,38 +87,22 @@ export const Drivetrain = ({
           key={index}
         />
       ))}
-
-      {/* Crank arm and pedal */}
-      {(() => {
-        const crankLength = 165.0; // 165mm standard crank
-        const crankAngleRad = state.crankAngle * (Math.PI / 180);
-        const crankEndWorld = {
-          x: chainringPos.x + crankLength * Math.cos(crankAngleRad),
-          y: chainringPos.y - crankLength * Math.sin(crankAngleRad),
-        };
-        const crankEndRotated = applyPitchRotation(crankEndWorld);
-        return (
-          <>
-            {/* Crank arm */}
-            <line
-              x1={toCanvasX(chainringRotated.x)}
-              y1={toCanvasY(chainringRotated.y)}
-              x2={toCanvasX(crankEndRotated.x)}
-              y2={toCanvasY(crankEndRotated.y)}
-              stroke="#6b7280"
-              strokeWidth="2.67"
-            />
-
-            {/* Pedal */}
-            <circle
-              cx={toCanvasX(crankEndRotated.x)}
-              cy={toCanvasY(crankEndRotated.y)}
-              r={5}
-              fill="#f5f5f5"
-            />
-          </>
-        );
-      })()}
+      {/* Crank arm */}
+      <line
+        x1={toCanvasX(chainringRotated.x)}
+        y1={toCanvasY(chainringRotated.y)}
+        x2={toCanvasX(crankEndRotated.x)}
+        y2={toCanvasY(crankEndRotated.y)}
+        stroke="#6b7280"
+        strokeWidth="2.67"
+      />
+      {/* Pedal */}
+      <circle
+        cx={toCanvasX(crankEndRotated.x)}
+        cy={toCanvasY(crankEndRotated.y)}
+        r={5}
+        fill="#f5f5f5"
+      />
     </>
   );
 };

--- a/components/visualization/Fork.tsx
+++ b/components/visualization/Fork.tsx
@@ -1,39 +1,13 @@
-import { getApplyPitchRotation } from "@/lib/kinematics";
-import {
-  BikeGeometry,
-  BoundsConversions,
-  computedProperties,
-  KinematicState,
-} from "@/lib/types";
+import { DrawComponentProps } from "./types";
 
 export const Fork = ({
   state,
-  geometry,
   conversion,
-}: {
-  state: KinematicState;
-  geometry: BikeGeometry;
-  conversion: BoundsConversions;
-}) => {
+}: DrawComponentProps) => {
   const { toCanvasX, toCanvasY } = conversion;
-  const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxle.world,
-    state.pitchAngleDegrees,
-  );
-  const headTubeBottom = computedProperties.headTubeBottom(geometry, state.bb.world);
-  const effectiveForkLength = geometry.forkLength - state.forkCompression;
-  const htaRad = computedProperties.headTubeAngleRadians(geometry);
-  const cosHT = Math.cos(htaRad);
-  const sinHT = Math.sin(htaRad);
-
-  const htBottomRotated = applyPitchRotation(headTubeBottom);
+  const htBottomRotated = state.headTubeBottom.wheelsOnGround;
+  const forkBendRotated = state.forkBend.wheelsOnGround;
   const frontAxleRotated = state.frontAxle.wheelsOnGround;
-
-  // Fork bend point (end of stanchions along steering axis)
-  const forkBendRotated = applyPitchRotation({
-    x: headTubeBottom.x + effectiveForkLength * cosHT,
-    y: headTubeBottom.y - effectiveForkLength * sinHT,
-  });
 
   return (
     <>

--- a/components/visualization/Fork.tsx
+++ b/components/visualization/Fork.tsx
@@ -17,37 +17,22 @@ export const Fork = ({
 }) => {
   const { toCanvasX, toCanvasY } = conversion;
   const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxlePosition,
+    state.rearAxle.world,
     state.pitchAngleDegrees,
   );
-  const headTubeBottom = computedProperties.headTubeBottom(
-    geometry,
-    state.bbPosition,
-  );
+  const headTubeBottom = computedProperties.headTubeBottom(geometry, state.bb.world);
   const effectiveForkLength = geometry.forkLength - state.forkCompression;
   const htaRad = computedProperties.headTubeAngleRadians(geometry);
   const cosHT = Math.cos(htaRad);
   const sinHT = Math.sin(htaRad);
-  const frontAxle = {
-    x:
-      headTubeBottom.x +
-      effectiveForkLength * cosHT +
-      geometry.forkOffset * sinHT,
-    y:
-      headTubeBottom.y -
-      effectiveForkLength * sinHT +
-      geometry.forkOffset * cosHT,
-  };
-  const frontAxleRotated = applyPitchRotation(frontAxle);
 
   const htBottomRotated = applyPitchRotation(headTubeBottom);
+  const frontAxleRotated = state.frontAxle.wheelsOnGround;
 
   // Fork bend point (end of stanchions along steering axis)
-  const forkBendWorldX = headTubeBottom.x + effectiveForkLength * cosHT;
-  const forkBendWorldY = headTubeBottom.y - effectiveForkLength * sinHT;
   const forkBendRotated = applyPitchRotation({
-    x: forkBendWorldX,
-    y: forkBendWorldY,
+    x: headTubeBottom.x + effectiveForkLength * cosHT,
+    y: headTubeBottom.y - effectiveForkLength * sinHT,
   });
 
   return (

--- a/components/visualization/FrontTriangle.tsx
+++ b/components/visualization/FrontTriangle.tsx
@@ -1,89 +1,70 @@
-import { degreesToRadians } from "@/lib/geometry";
-import { getApplyPitchRotation } from "@/lib/kinematics";
-import { computedProperties } from "@/lib/types";
 import { DrawComponentProps } from "./types";
 
 export const FrontTriangle = ({
   state,
-  geometry,
   conversion,
 }: DrawComponentProps) => {
-  const bbPos = state.bb.world;
   const { toCanvasX, toCanvasY } = conversion;
-  const seatAngleRad = degreesToRadians(geometry.seatAngle);
-  const seatTopWorldX =
-    bbPos.x - geometry.seatTubeLength * Math.cos(seatAngleRad);
-  const seatTopWorldY =
-    bbPos.y + geometry.seatTubeLength * Math.sin(seatAngleRad);
-  const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxle.world,
-    state.pitchAngleDegrees,
-  );
-  const seatTopRotated = applyPitchRotation({
-    x: seatTopWorldX,
-    y: seatTopWorldY,
-  });
 
-  // Downtube junction (20mm above head tube bottom in world coords)
-  const headTubeBottom = computedProperties.headTubeBottom(geometry, bbPos);
-  const headTubeTop = computedProperties.headTubeTop(geometry, bbPos);
-  const downtubeJunctionY = headTubeBottom.y + 20;
-  const downtubeJunctionWorldX = headTubeBottom.x;
-  const downtubeJunctionRotated = applyPitchRotation({
-    x: downtubeJunctionWorldX,
-    y: downtubeJunctionY,
-  });
-  const bbPosRotated = state.bb.wheelsOnGround;
+  const bbCanvasX = toCanvasX(state.bb.wheelsOnGround.x);
+  const bbCanvasY = toCanvasY(state.bb.wheelsOnGround.y);
+  const htTopCanvasX = toCanvasX(state.headTubeTop.wheelsOnGround.x);
+  const htTopCanvasY = toCanvasY(state.headTubeTop.wheelsOnGround.y);
+  const htBottomCanvasX = toCanvasX(state.headTubeBottom.wheelsOnGround.x);
+  const htBottomCanvasY = toCanvasY(state.headTubeBottom.wheelsOnGround.y);
+  const seatTopCanvasX = toCanvasX(state.seatTop.wheelsOnGround.x);
+  const seatTopCanvasY = toCanvasY(state.seatTop.wheelsOnGround.y);
 
-  const htTopRotated = applyPitchRotation(headTubeTop);
-  const htBottomRotated = applyPitchRotation(headTubeBottom);
+  // Downtube junction: ~20mm above head tube bottom in screen space (small-angle approx)
+  const downtubeJunctionX = htBottomCanvasX;
+  const downtubeJunctionY = htBottomCanvasY - 20 * conversion.scale;
 
   return (
     <>
       {/* Downtube - BB to head tube junction */}
       <line
-        x1={toCanvasX(bbPosRotated.x)}
-        y1={toCanvasY(bbPosRotated.y)}
-        x2={toCanvasX(downtubeJunctionRotated.x)}
-        y2={toCanvasY(downtubeJunctionRotated.y)}
+        x1={bbCanvasX}
+        y1={bbCanvasY}
+        x2={downtubeJunctionX}
+        y2={downtubeJunctionY}
         stroke="#2563eb"
         strokeWidth="2.67"
       />
 
       {/* Head tube */}
       <line
-        x1={toCanvasX(htBottomRotated.x)}
-        y1={toCanvasY(htBottomRotated.y)}
-        x2={toCanvasX(htTopRotated.x)}
-        y2={toCanvasY(htTopRotated.y)}
+        x1={htBottomCanvasX}
+        y1={htBottomCanvasY}
+        x2={htTopCanvasX}
+        y2={htTopCanvasY}
         stroke="#2563eb"
         strokeWidth="2.67"
       />
 
       {/* Seat tube - BB to seat top */}
       <line
-        x1={toCanvasX(bbPosRotated.x)}
-        y1={toCanvasY(bbPosRotated.y)}
-        x2={toCanvasX(seatTopRotated.x)}
-        y2={toCanvasY(seatTopRotated.y)}
+        x1={bbCanvasX}
+        y1={bbCanvasY}
+        x2={seatTopCanvasX}
+        y2={seatTopCanvasY}
         stroke="#2563eb"
         strokeWidth="2.67"
       />
 
       {/* Top tube - head tube top to seat top */}
       <line
-        x1={toCanvasX(htTopRotated.x)}
-        y1={toCanvasY(htTopRotated.y)}
-        x2={toCanvasX(seatTopRotated.x)}
-        y2={toCanvasY(seatTopRotated.y)}
+        x1={htTopCanvasX}
+        y1={htTopCanvasY}
+        x2={seatTopCanvasX}
+        y2={seatTopCanvasY}
         stroke="#2563eb"
         strokeWidth="1.33"
       />
 
       {/* Bottom bracket */}
       <circle
-        cx={toCanvasX(bbPosRotated.x)}
-        cy={toCanvasY(bbPosRotated.y)}
+        cx={bbCanvasX}
+        cy={bbCanvasY}
         r={4}
         fill="#06b6d4"
       />

--- a/components/visualization/FrontTriangle.tsx
+++ b/components/visualization/FrontTriangle.tsx
@@ -8,7 +8,7 @@ export const FrontTriangle = ({
   geometry,
   conversion,
 }: DrawComponentProps) => {
-  const bbPos = state.bbPosition;
+  const bbPos = state.bb.world;
   const { toCanvasX, toCanvasY } = conversion;
   const seatAngleRad = degreesToRadians(geometry.seatAngle);
   const seatTopWorldX =
@@ -16,7 +16,7 @@ export const FrontTriangle = ({
   const seatTopWorldY =
     bbPos.y + geometry.seatTubeLength * Math.sin(seatAngleRad);
   const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxlePosition,
+    state.rearAxle.world,
     state.pitchAngleDegrees,
   );
   const seatTopRotated = applyPitchRotation({
@@ -25,21 +25,15 @@ export const FrontTriangle = ({
   });
 
   // Downtube junction (20mm above head tube bottom in world coords)
-  const headTubeBottom = computedProperties.headTubeBottom(
-    geometry,
-    state.bbPosition,
-  );
-  const headTubeTop = computedProperties.headTubeTop(
-    geometry,
-    state.bbPosition,
-  );
+  const headTubeBottom = computedProperties.headTubeBottom(geometry, bbPos);
+  const headTubeTop = computedProperties.headTubeTop(geometry, bbPos);
   const downtubeJunctionY = headTubeBottom.y + 20;
   const downtubeJunctionWorldX = headTubeBottom.x;
   const downtubeJunctionRotated = applyPitchRotation({
     x: downtubeJunctionWorldX,
     y: downtubeJunctionY,
   });
-  const bbPosRotated = applyPitchRotation(bbPos);
+  const bbPosRotated = state.bb.wheelsOnGround;
 
   const htTopRotated = applyPitchRotation(headTubeTop);
   const htBottomRotated = applyPitchRotation(headTubeBottom);

--- a/components/visualization/FrontTriangle.tsx
+++ b/components/visualization/FrontTriangle.tsx
@@ -15,9 +15,19 @@ export const FrontTriangle = ({
   const seatTopCanvasX = toCanvasX(state.seatTop.wheelsOnGround.x);
   const seatTopCanvasY = toCanvasY(state.seatTop.wheelsOnGround.y);
 
-  // Downtube junction: ~20mm above head tube bottom in screen space (small-angle approx)
-  const downtubeJunctionX = htBottomCanvasX;
-  const downtubeJunctionY = htBottomCanvasY - 20 * conversion.scale;
+  // Downtube junction: 20mm above head tube bottom along head tube direction in wheelsOnGround space
+  const headTubeDeltaX =
+    state.headTubeTop.wheelsOnGround.x - state.headTubeBottom.wheelsOnGround.x;
+  const headTubeDeltaY =
+    state.headTubeTop.wheelsOnGround.y - state.headTubeBottom.wheelsOnGround.y;
+  const headTubeLength = Math.hypot(headTubeDeltaX, headTubeDeltaY);
+  const downtubeOffset = headTubeLength === 0 ? 0 : 20 / headTubeLength;
+  const downtubeJunctionX = toCanvasX(
+    state.headTubeBottom.wheelsOnGround.x + headTubeDeltaX * downtubeOffset,
+  );
+  const downtubeJunctionY = toCanvasY(
+    state.headTubeBottom.wheelsOnGround.y + headTubeDeltaY * downtubeOffset,
+  );
 
   return (
     <>

--- a/components/visualization/Measurements.tsx
+++ b/components/visualization/Measurements.tsx
@@ -1,6 +1,5 @@
 import { computedProperties } from "@/lib/types";
 import { DrawComponentProps } from "./types";
-import { getApplyPitchRotation } from "@/lib/kinematics";
 
 export const Measurements = ({
   conversion,
@@ -8,13 +7,9 @@ export const Measurements = ({
   geometry,
 }: DrawComponentProps) => {
   const { toCanvasX, toCanvasY, scale, height, padding } = conversion;
-  const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxlePosition,
-    state.pitchAngleDegrees,
-  );
-  const bbPosRotated = applyPitchRotation(state.bbPosition);
-  const rearAxlePosRotated = applyPitchRotation(state.rearAxlePosition);
-  const frontAxleRotated = applyPitchRotation(state.frontAxlePosition);
+  const bbPosRotated = state.bb.wheelsOnGround;
+  const rearAxlePosRotated = state.rearAxle.wheelsOnGround;
+  const frontAxleRotated = state.frontAxle.wheelsOnGround;
 
   const groundY = toCanvasY(computedProperties.rearWheelRadius(geometry));
   const bbScreenX = toCanvasX(bbPosRotated.x);
@@ -22,7 +17,7 @@ export const Measurements = ({
   const rearAxleScreenX = toCanvasX(rearAxlePosRotated.x);
   const frontAxleScreenX = toCanvasX(frontAxleRotated.x);
 
-  const bbHeight = state.bbPosition.y;
+  const bbHeight = state.bb.world.y;
   const rearCenter = Math.abs(rearAxlePosRotated.x - bbPosRotated.x);
   const frontCenter = Math.abs(frontAxleRotated.x - bbPosRotated.x) / scale;
 
@@ -144,9 +139,9 @@ export const Measurements = ({
 
       {/* F/R Balance */}
       {(() => {
-        const wheelbase = state.frontAxlePosition.x - state.rearAxlePosition.x;
-        const comX = state.bbPosition.x + geometry.comX;
-        const distanceFromRear = comX - state.rearAxlePosition.x;
+        const wheelbase = state.frontAxle.world.x - state.rearAxle.world.x;
+        const comX = state.bb.world.x + geometry.comX;
+        const distanceFromRear = comX - state.rearAxle.world.x;
         const frontPercentage = (distanceFromRear / wheelbase) * 100;
         const rearPercentage = 100 - frontPercentage;
 

--- a/components/visualization/Shock.tsx
+++ b/components/visualization/Shock.tsx
@@ -1,17 +1,8 @@
-import { getApplyPitchRotation } from "@/lib/kinematics";
 import { DrawComponentProps } from "./types";
 
-export const Shock = ({ conversion, state, geometry }: DrawComponentProps) => {
+export const Shock = ({ conversion, state }: DrawComponentProps) => {
   const { toCanvasX, toCanvasY } = conversion;
-  const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxle.world,
-    state.pitchAngleDegrees,
-  );
-  const frameMountRotated = applyPitchRotation({
-    x: state.bb.world.x + geometry.shockFrameMountX,
-    y: state.bb.world.y + geometry.shockFrameMountY,
-  });
-
+  const frameMountRotated = state.shockFrameMount.wheelsOnGround;
   const shockEyePosRotated = state.swingarmEye.wheelsOnGround;
 
   return (

--- a/components/visualization/Shock.tsx
+++ b/components/visualization/Shock.tsx
@@ -4,15 +4,15 @@ import { DrawComponentProps } from "./types";
 export const Shock = ({ conversion, state, geometry }: DrawComponentProps) => {
   const { toCanvasX, toCanvasY } = conversion;
   const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxlePosition,
+    state.rearAxle.world,
     state.pitchAngleDegrees,
   );
   const frameMountRotated = applyPitchRotation({
-    x: state.bbPosition.x + geometry.shockFrameMountX,
-    y: state.bbPosition.y + geometry.shockFrameMountY,
+    x: state.bb.world.x + geometry.shockFrameMountX,
+    y: state.bb.world.y + geometry.shockFrameMountY,
   });
 
-  const shockEyePosRotated = applyPitchRotation(state.swingarmEyePosition);
+  const shockEyePosRotated = state.swingarmEye.wheelsOnGround;
 
   return (
     <>

--- a/components/visualization/Swingarm.tsx
+++ b/components/visualization/Swingarm.tsx
@@ -1,22 +1,14 @@
-import { getApplyPitchRotation } from "@/lib/kinematics";
 import { DrawComponentProps } from "./types";
 import { pointsToPolylineString } from "./lib";
 
-
-
 export const Swingarm = ({ state, conversion }: DrawComponentProps) => {
-  const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxlePosition,
-    state.pitchAngleDegrees,
-  );
   const { toCanvas } = conversion;
-  const statePoints = [
-    state.pivotPosition,
-    state.swingarmEyePosition,
-    state.rearAxlePosition,
-    state.pivotPosition,
-  ];
-  const canvasPoints = statePoints.map(applyPitchRotation).map(toCanvas);
+  const canvasPoints = [
+    state.pivot.wheelsOnGround,
+    state.swingarmEye.wheelsOnGround,
+    state.rearAxle.wheelsOnGround,
+    state.pivot.wheelsOnGround,
+  ].map(toCanvas);
   const polylineString = pointsToPolylineString(canvasPoints);
   return (
     <>

--- a/components/visualization/Wheels.tsx
+++ b/components/visualization/Wheels.tsx
@@ -1,34 +1,10 @@
-import { getApplyPitchRotation } from "@/lib/kinematics";
 import { computedProperties } from "@/lib/types";
 import { DrawComponentProps } from "./types";
 
 export const Wheels = ({ state, geometry, conversion }: DrawComponentProps) => {
   const { toCanvasX, toCanvasY } = conversion;
-  const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxlePosition,
-    state.pitchAngleDegrees,
-  );
-  const headTubeBottom = computedProperties.headTubeBottom(
-    geometry,
-    state.bbPosition,
-  );
-
-  const effectiveForkLength = geometry.forkLength - state.forkCompression;
-  const htaRad = computedProperties.headTubeAngleRadians(geometry);
-  const cosHT = Math.cos(htaRad);
-  const sinHT = Math.sin(htaRad);
-  const frontAxle = {
-    x:
-      headTubeBottom.x +
-      effectiveForkLength * cosHT +
-      geometry.forkOffset * sinHT,
-    y:
-      headTubeBottom.y -
-      effectiveForkLength * sinHT +
-      geometry.forkOffset * cosHT,
-  };
-  const frontAxleRotated = applyPitchRotation(frontAxle);
-  const rearAxleRotated = applyPitchRotation(state.rearAxlePosition);
+  const frontAxleRotated = state.frontAxle.wheelsOnGround;
+  const rearAxleRotated = state.rearAxle.wheelsOnGround;
   return (
     <>
       {/* Front wheel */}

--- a/components/visualization/types.ts
+++ b/components/visualization/types.ts
@@ -1,7 +1,7 @@
-import { BikeGeometry, BoundsConversions, KinematicState } from "@/lib/types";
+import { BikeGeometry, BoundsConversions, BikeState } from "@/lib/types";
 
 export type DrawComponentProps = {
   geometry: BikeGeometry;
-  state: KinematicState;
+  state: BikeState;
   conversion: BoundsConversions;
 };

--- a/lib/kinematics.test.ts
+++ b/lib/kinematics.test.ts
@@ -19,30 +19,30 @@ describe("Rigid Triangle Constraint", () => {
 
     // Calculate triangle sides at first state (top-out)
     const firstPivotToEye = distance(
-      firstState.pivotPosition,
-      firstState.swingarmEyePosition,
+      firstState.pivot.world,
+      firstState.swingarmEye.world,
     );
     const firstPivotToAxle = distance(
-      firstState.pivotPosition,
-      firstState.rearAxlePosition,
+      firstState.pivot.world,
+      firstState.rearAxle.world,
     );
     const firstEyeToAxle = distance(
-      firstState.swingarmEyePosition,
-      firstState.rearAxlePosition,
+      firstState.swingarmEye.world,
+      firstState.rearAxle.world,
     );
 
     // Calculate triangle sides at last state (full compression)
     const lastPivotToEye = distance(
-      lastState.pivotPosition,
-      lastState.swingarmEyePosition,
+      lastState.pivot.world,
+      lastState.swingarmEye.world,
     );
     const lastPivotToAxle = distance(
-      lastState.pivotPosition,
-      lastState.rearAxlePosition,
+      lastState.pivot.world,
+      lastState.rearAxle.world,
     );
     const lastEyeToAxle = distance(
-      lastState.swingarmEyePosition,
-      lastState.rearAxlePosition,
+      lastState.swingarmEye.world,
+      lastState.rearAxle.world,
     );
 
     // The swingarm is rigid, so these distances should be constant throughout travel
@@ -63,7 +63,7 @@ describe("Rigid Triangle Constraint", () => {
     const TOLERANCE = 0.1; // mm
 
     for (const state of results.states) {
-      const pivotToAxle = distance(state.pivotPosition, state.rearAxlePosition);
+      const pivotToAxle = distance(state.pivot.world, state.rearAxle.world);
       expect(Math.abs(pivotToAxle - geometry.swingarmLength)).toBeLessThan(
         TOLERANCE,
       );
@@ -79,28 +79,28 @@ describe("Rigid Triangle Constraint", () => {
 
     // Reference triangle sides at top-out
     const referencePivotToEye = distance(
-      firstState.pivotPosition,
-      firstState.swingarmEyePosition,
+      firstState.pivot.world,
+      firstState.swingarmEye.world,
     );
     const referencePivotToAxle = distance(
-      firstState.pivotPosition,
-      firstState.rearAxlePosition,
+      firstState.pivot.world,
+      firstState.rearAxle.world,
     );
     const referenceEyeToAxle = distance(
-      firstState.swingarmEyePosition,
-      firstState.rearAxlePosition,
+      firstState.swingarmEye.world,
+      firstState.rearAxle.world,
     );
 
     // Check that all states maintain the same triangle geometry
     for (const state of results.states) {
       const pivotToEye = distance(
-        state.pivotPosition,
-        state.swingarmEyePosition,
+        state.pivot.world,
+        state.swingarmEye.world,
       );
-      const pivotToAxle = distance(state.pivotPosition, state.rearAxlePosition);
+      const pivotToAxle = distance(state.pivot.world, state.rearAxle.world);
       const eyeToAxle = distance(
-        state.swingarmEyePosition,
-        state.rearAxlePosition,
+        state.swingarmEye.world,
+        state.rearAxle.world,
       );
 
       expect(Math.abs(pivotToEye - referencePivotToEye)).toBeLessThan(
@@ -143,18 +143,18 @@ describe("Rigid Triangle Constraint", () => {
 
       // Rear wheel contact point (always at ground level, x = rear axle x)
       const rearContactGround = {
-        x: state.rearAxlePosition.x,
+        x: state.rearAxle.world.x,
         y: 0, // ground level
       };
 
       // Rotate both axles by pitch angle (rotation center is rear axle on ground)
       const rotatedRearAxle = applyPitchRotation(
-        state.rearAxlePosition,
+        state.rearAxle.world,
         rearContactGround,
         state.pitchAngleDegrees,
       );
       const rotatedFrontAxle = applyPitchRotation(
-        state.frontAxlePosition,
+        state.frontAxle.world,
         rearContactGround,
         state.pitchAngleDegrees,
       );
@@ -301,8 +301,8 @@ describe("getIdlerPosition", () => {
     });
     const result = getIdlerPosition(baseState, geometry);
     expect(result).not.toBeNull();
-    expect(result?.x).toBeCloseTo(baseState.bbPosition.x + (-60));
-    expect(result?.y).toBeCloseTo(baseState.bbPosition.y + 160);
+    expect(result?.x).toBeCloseTo(baseState.bb.world.x + (-60));
+    expect(result?.y).toBeCloseTo(baseState.bb.world.y + 160);
   });
 
   it("returns a point for swingarm-mounted idler", () => {
@@ -351,7 +351,7 @@ describe("getRotatedCentreOfMass", () => {
     const state = results.states[0];
     const geometry = createDefaultGeometry();
     const applyPitch = getApplyPitchRotation(
-      state.rearAxlePosition,
+      state.rearAxle.world,
       state.pitchAngleDegrees,
     );
     const com = getRotatedCentreOfMass(state, geometry, applyPitch);
@@ -366,14 +366,13 @@ describe("getRotatedCentreOfMass", () => {
     const results = runKinematicAnalysis(geometry);
     const state = results.states[0]; // top-out: pitch ≈ 0
     const applyPitch = getApplyPitchRotation(
-      state.rearAxlePosition,
+      state.rearAxle.world,
       state.pitchAngleDegrees,
     );
     const com = getRotatedCentreOfMass(state, geometry, applyPitch);
-    // At near-zero pitch the rotated CoM y is approximately bbPosition.y + comY
+    // At near-zero pitch the rotated CoM y is approximately bb.world.y + comY
     // Allow a few mm tolerance for the small but non-zero pitch angle
-    expect(com.y).toBeCloseTo(state.bbPosition.y + geometry.comY, -1);
+    expect(com.y).toBeCloseTo(state.bb.world.y + geometry.comY, -1);
   });
 });
-
 

--- a/lib/kinematics.ts
+++ b/lib/kinematics.ts
@@ -2,7 +2,7 @@
 import {
   BikeGeometry,
   KinematicState,
-  KinematicStateFirstPass,
+  KinematicPoint,
   AnalysisResults,
   Point2D,
   computedProperties,
@@ -29,6 +29,17 @@ interface RigidTriangle {
   axleAngleIsPositive: boolean;
 }
 
+// Internal first-pass state — not exported
+interface FirstPassState {
+  travelMM: number;
+  rearAxlePosition: Point2D;
+  bbPosition: Point2D;
+  pivotPosition: Point2D;
+  swingarmEyePosition: Point2D;
+  shockLength: number;
+  proportionalForkStroke: number;
+}
+
 export function runKinematicAnalysis(geometry: BikeGeometry): AnalysisResults {
   const rigidTriangle = establishRigidTriangle(geometry);
 
@@ -36,143 +47,106 @@ export function runKinematicAnalysis(geometry: BikeGeometry): AnalysisResults {
   const strokeSteps = Math.floor(geometry.shockStroke / stepSize) + 1;
 
   // First pass: calculate basic geometric state from shock stroke only
-  const firstPassStates: (KinematicStateFirstPass & {
-    proportionalForkStroke: number;
-  })[] = [];
+  const firstPassStates: FirstPassState[] = [];
   for (let step = 0; step < strokeSteps; step++) {
-    const shockStroke = step * stepSize; // mm of shock compression
-
-    // Calculate proportional fork compression
+    const shockStroke = step * stepSize;
     const travelRatio = shockStroke / geometry.shockStroke;
     const proportionalForkStroke = travelRatio * geometry.forkTravel;
-
-    const state = calculateStateAtShockStroke(
-      shockStroke,
-      geometry,
-      rigidTriangle,
-    );
-
-    firstPassStates.push({
-      ...state,
-      proportionalForkStroke,
-    });
+    const state = calculateStateAtShockStroke(shockStroke, geometry, rigidTriangle);
+    firstPassStates.push({ ...state, proportionalForkStroke });
   }
 
-  // Second pass: extend first-pass states with derived values
+  // Second pass: build full KinematicState with no dummy initialisation
   const states: KinematicState[] = [];
   const axlePath: Point2D[] = [];
   const frontAxlePath: Point2D[] = [];
 
   for (let i = 0; i < firstPassStates.length; i++) {
-    const firstPassState = firstPassStates[i];
+    const fp = firstPassStates[i];
 
-    // Calculate front axle position with proportional fork compression
+    // Front axle with proportional fork compression
     const htaRad = computedProperties.headTubeAngleRadians(geometry);
-    const effectiveForkLength =
-      geometry.forkLength - firstPassState.proportionalForkStroke;
-
+    const effectiveForkLength = geometry.forkLength - fp.proportionalForkStroke;
     const frontAxlePos: Point2D = {
       x:
-        firstPassState.bbPosition.x +
+        fp.bbPosition.x +
         geometry.reach +
         geometry.headTubeLength * Math.cos(htaRad) +
         effectiveForkLength * Math.cos(htaRad) +
         geometry.forkOffset * Math.sin(htaRad),
       y:
-        firstPassState.bbPosition.y +
+        fp.bbPosition.y +
         geometry.stack -
         geometry.headTubeLength * Math.sin(htaRad) -
         effectiveForkLength * Math.sin(htaRad) +
         geometry.forkOffset * Math.cos(htaRad),
     };
 
-    // Recalculate pitch angle with the actual front axle position
-    const dx = frontAxlePos.x - firstPassState.rearAxlePosition.x;
-    const dy = frontAxlePos.y - firstPassState.rearAxlePosition.y;
+    // Pitch angle from actual front axle position
+    const dx = frontAxlePos.x - fp.rearAxlePosition.x;
+    const dy = frontAxlePos.y - fp.rearAxlePosition.y;
     const centerDist = Math.sqrt(dx * dx + dy * dy);
-
     const centerAngle = Math.atan2(dy, dx);
     const frontWheelRadius = computedProperties.frontWheelRadius(geometry);
     const rearWheelRadius = computedProperties.rearWheelRadius(geometry);
     const radiusDiff = frontWheelRadius - rearWheelRadius;
     const angleOffset = Math.asin(radiusDiff / centerDist);
-    const tangentAngle = centerAngle - angleOffset;
-    const pitchAngleDegrees = (tangentAngle * 180.0) / Math.PI;
+    const pitchAngleDegrees = ((centerAngle - angleOffset) * 180.0) / Math.PI;
 
-    // Create the full kinematic state by extending the first-pass state
+    // Build pitch rotation function once for this state
+    const applyPitchRotation = getApplyPitchRotation(fp.rearAxlePosition, pitchAngleDegrees);
+    const toKP = (p: Point2D): KinematicPoint => ({
+      world: p,
+      wheelsOnGround: applyPitchRotation(p),
+    });
+
+    // Leverage ratio (numerical derivative)
+    let leverageRatio: number;
+    if (i === 0) {
+      if (firstPassStates.length > 1) {
+        const dTravel = firstPassStates[i + 1].travelMM - firstPassStates[i].travelMM;
+        leverageRatio = dTravel / stepSize;
+      } else {
+        leverageRatio = 1.0;
+      }
+    } else if (i === firstPassStates.length - 1) {
+      const dTravel = firstPassStates[i].travelMM - firstPassStates[i - 1].travelMM;
+      leverageRatio = dTravel / stepSize;
+    } else {
+      const dTravel = firstPassStates[i + 1].travelMM - firstPassStates[i - 1].travelMM;
+      leverageRatio = dTravel / (2 * stepSize);
+    }
+
+    const wheelRate = geometry.shockSpringRate / (leverageRatio * leverageRatio);
+
+    const antiSquat = calculateVisualAntiSquat(fp, frontAxlePos, geometry, applyPitchRotation);
+    const antiRise = calculateVisualAntiRise(fp, frontAxlePos, geometry, applyPitchRotation);
+    const trail = computeTrail(fp, frontAxlePos, geometry, applyPitchRotation);
+
     const state: KinematicState = {
-      travelMM: firstPassState.travelMM,
-      rearAxlePosition: firstPassState.rearAxlePosition,
-      bbPosition: firstPassState.bbPosition,
-      pivotPosition: firstPassState.pivotPosition,
-      swingarmEyePosition: firstPassState.swingarmEyePosition,
-      shockLength: firstPassState.shockLength,
+      travelMM: fp.travelMM,
+      shockLength: fp.shockLength,
       pitchAngleDegrees,
-      frontAxlePosition: frontAxlePos,
-      forkCompression: firstPassState.proportionalForkStroke,
-      leverageRatio: 0,
-      wheelRate: 0,
-      antiSquat: 0,
-      antiRise: 0,
+      forkCompression: fp.proportionalForkStroke,
+      rearAxle: toKP(fp.rearAxlePosition),
+      frontAxle: toKP(frontAxlePos),
+      bb: toKP(fp.bbPosition),
+      pivot: toKP(fp.pivotPosition),
+      swingarmEye: toKP(fp.swingarmEyePosition),
+      leverageRatio,
+      wheelRate,
+      antiSquat,
+      antiRise,
       pedalKickback: 0,
       chainGrowth: 0,
       totalChainGrowth: 0,
-      trail: 0,
+      trail,
       crankAngle: 0,
     };
 
-    // Calculate leverage ratio as dWheelTravel / dShockStroke (numerical derivative)
-    if (i === 0) {
-      // At first point: use forward difference
-      if (firstPassStates.length > 1) {
-        const wheelTravelDelta =
-          firstPassStates[i + 1].travelMM - firstPassStates[i].travelMM;
-        const shockStrokeDelta = stepSize;
-        state.leverageRatio =
-          shockStrokeDelta > 0 ? wheelTravelDelta / shockStrokeDelta : 1.0;
-      } else {
-        state.leverageRatio = 1.0;
-      }
-    } else if (i === firstPassStates.length - 1) {
-      // At last point: use backward difference
-      const wheelTravelDelta =
-        firstPassStates[i].travelMM - firstPassStates[i - 1].travelMM;
-      const shockStrokeDelta = stepSize;
-      state.leverageRatio =
-        shockStrokeDelta > 0 ? wheelTravelDelta / shockStrokeDelta : 1.0;
-    } else {
-      // In the middle: use central difference for better accuracy
-      const wheelTravelDelta =
-        firstPassStates[i + 1].travelMM - firstPassStates[i - 1].travelMM;
-      const shockStrokeDelta = 2 * stepSize;
-      state.leverageRatio =
-        shockStrokeDelta > 0 ? wheelTravelDelta / shockStrokeDelta : 1.0;
-    }
-
-    // Calculate wheel rate using actual leverage ratio
-    state.wheelRate =
-      geometry.shockSpringRate / (state.leverageRatio * state.leverageRatio);
-
-    // Calculate anti-squat and anti-rise from visual geometry
-    state.antiSquat = calculateVisualAntiSquat(state, geometry);
-    state.antiRise = calculateVisualAntiRise(state, geometry);
-
-    state.trail = computeTrail(state, geometry);
-
     states.push(state);
-
-    // Store wheel positions relative to BB
-    const rearRelativeToBB: Point2D = {
-      x: state.rearAxlePosition.x - state.bbPosition.x,
-      y: state.rearAxlePosition.y - state.bbPosition.y,
-    };
-    const frontRelativeToBB: Point2D = {
-      x: state.frontAxlePosition.x - state.bbPosition.x,
-      y: state.frontAxlePosition.y - state.bbPosition.y,
-    };
-
-    axlePath.push(rearRelativeToBB);
-    frontAxlePath.push(frontRelativeToBB);
+    axlePath.push(Point2D.subtract(fp.rearAxlePosition, fp.bbPosition));
+    frontAxlePath.push(Point2D.subtract(frontAxlePos, fp.bbPosition));
   }
 
   return { states, axlePath, frontAxlePath };
@@ -181,7 +155,6 @@ export function runKinematicAnalysis(geometry: BikeGeometry): AnalysisResults {
 function establishRigidTriangle(geometry: BikeGeometry): RigidTriangle {
   const rearWheelRadius = computedProperties.rearWheelRadius(geometry);
 
-  // At top-out: BB is at bbHeight, shock is at shockETE
   const pivot: Point2D = {
     x: geometry.bbToPivotX,
     y: geometry.bbHeight + geometry.bbToPivotY,
@@ -213,8 +186,7 @@ function establishRigidTriangle(geometry: BikeGeometry): RigidTriangle {
 
   const verticalDist = rearWheelRadius - pivot.y;
   const horizontalDistSquared =
-    geometry.swingarmLength * geometry.swingarmLength -
-    verticalDist * verticalDist;
+    geometry.swingarmLength * geometry.swingarmLength - verticalDist * verticalDist;
 
   if (horizontalDistSquared < 0) {
     return {
@@ -227,10 +199,8 @@ function establishRigidTriangle(geometry: BikeGeometry): RigidTriangle {
   }
 
   const horizontalDist = Math.sqrt(horizontalDistSquared);
-
   const axle1: Point2D = { x: pivot.x + horizontalDist, y: rearWheelRadius };
   const axle2: Point2D = { x: pivot.x - horizontalDist, y: rearWheelRadius };
-
   const axle = axle1.x < axle2.x ? axle1 : axle2;
 
   const pivotToEyeDist = distance(pivot, chosenEye);
@@ -242,11 +212,9 @@ function establishRigidTriangle(geometry: BikeGeometry): RigidTriangle {
       pivotToAxleDist * pivotToAxleDist -
       eyeToAxleDist * eyeToAxleDist) /
     (2 * pivotToEyeDist * pivotToAxleDist);
-  // const angleAtPivot = Math.acos(Math.max(-1, Math.min(1, cosAngle)));
   const angleAtPivot = Math.acos(cosAngle);
 
   const pivotToEyeAngle = angle(pivot, chosenEye);
-  // const pivotToAxleAngle = angle(pivot, axle);
 
   const testAnglePlus = pivotToEyeAngle + angleAtPivot;
   const testAngleMinus = pivotToEyeAngle - angleAtPivot;
@@ -262,7 +230,6 @@ function establishRigidTriangle(geometry: BikeGeometry): RigidTriangle {
 
   const distPlus = distance(testAxlePlus, axle);
   const distMinus = distance(testAxleMinus, axle);
-
   const axleAngleIsPositive = distPlus < distMinus;
 
   return {
@@ -278,9 +245,8 @@ function calculateStateAtShockStroke(
   shockStroke: number,
   geometry: BikeGeometry,
   rigidTriangle: RigidTriangle,
-): KinematicStateFirstPass {
+): Omit<FirstPassState, "proportionalForkStroke"> {
   const rearWheelRadius = computedProperties.rearWheelRadius(geometry);
-  // const frontWheelRadius = computedProperties.frontWheelRadius(geometry);
 
   const eyeToAxleDistance = rigidTriangle.eyeToAxle;
   const currentShockLength = geometry.shockETE - shockStroke;
@@ -309,20 +275,14 @@ function calculateStateAtShockStroke(
       pivotPosition: pivot,
       swingarmEyePosition: { x: 0, y: 0 },
       shockLength: currentShockLength,
-      pitchAngleDegrees: 0,
     };
   }
 
-  // CRITICAL: Always use the same eye candidate index determined at top-out
-  // This locks in the triangle orientation and prevents flipping
   const chosenEye = eyeCandidates[rigidTriangle.correctEyeIndex];
 
-  // Find axle using rigid triangle constraint
-  // We know: pivot position, eye position, all three side lengths (fixed)
   const pivotToEyeDist = distance(pivot, chosenEye);
   const pivotToAxleDist = rigidTriangle.pivotToAxle;
 
-  // Law of cosines: angle at pivot in the triangle
   const cosAngle =
     (pivotToEyeDist * pivotToEyeDist +
       pivotToAxleDist * pivotToAxleDist -
@@ -331,35 +291,21 @@ function calculateStateAtShockStroke(
   const angleAtPivot = Math.acos(cosAngle);
 
   const pivotToEyeAngle = angle(pivot, chosenEye);
-
-  // Use the rigid triangle orientation to pick the correct axle
-  // No tracking or selection needed - the orientation is fixed throughout travel!
   const axleAngle = rigidTriangle.axleAngleIsPositive
-    ? pivotToEyeAngle + angleAtPivot // Positive: add angle
-    : pivotToEyeAngle - angleAtPivot; // Negative: subtract angle
+    ? pivotToEyeAngle + angleAtPivot
+    : pivotToEyeAngle - angleAtPivot;
 
   const nominalAxle: Point2D = {
     x: pivot.x + pivotToAxleDist * Math.cos(axleAngle),
     y: pivot.y + pivotToAxleDist * Math.sin(axleAngle),
   };
 
-  // Adjust entire frame DOWN so rear axle is on ground
   const groundOffset = nominalAxle.y - rearWheelRadius;
   const bbY = geometry.bbHeight - groundOffset;
 
-  // Final positions (no pitch adjustment)
-  const rearAxlePos: Point2D = {
-    x: nominalAxle.x,
-    y: rearWheelRadius,
-  };
-  const bbPos: Point2D = {
-    x: 0,
-    y: bbY,
-  };
-  const pivotPos: Point2D = {
-    x: geometry.bbToPivotX,
-    y: pivot.y - groundOffset,
-  };
+  const rearAxlePos: Point2D = { x: nominalAxle.x, y: rearWheelRadius };
+  const bbPos: Point2D = { x: 0, y: bbY };
+  const pivotPos: Point2D = { x: geometry.bbToPivotX, y: pivot.y - groundOffset };
   const swingarmEyePos: Point2D = {
     x: chosenEye.x,
     y: chosenEye.y - groundOffset,
@@ -369,66 +315,31 @@ function calculateStateAtShockStroke(
     y: bbY + geometry.shockFrameMountY,
   };
 
-  // Calculate front wheel position
-  const htaRad = geometry.headAngle * (Math.PI / 180);
-  const frontAxlePos: Point2D = {
-    x:
-      bbPos.x +
-      geometry.reach +
-      geometry.headTubeLength * Math.cos(htaRad) +
-      geometry.forkLength * Math.cos(htaRad) +
-      geometry.forkOffset * Math.sin(htaRad),
-    y:
-      bbPos.y +
-      geometry.stack -
-      geometry.headTubeLength * Math.sin(htaRad) -
-      geometry.forkLength * Math.sin(htaRad) +
-      geometry.forkOffset * Math.cos(htaRad),
-  };
-
-  // Calculate pitch angle
-  const dx = frontAxlePos.x - rearAxlePos.x;
-  const dy = frontAxlePos.y - rearAxlePos.y;
-  const centerDist = Math.sqrt(dx * dx + dy * dy);
-
-  const centerAngle = Math.atan2(dy, dx);
-  const frontWheelRadius = computedProperties.frontWheelRadius(geometry);
-  const radiusDiff = frontWheelRadius - rearWheelRadius;
-  const angleOffset = Math.asin(radiusDiff / centerDist);
-  const tangentAngle = centerAngle - angleOffset;
-
-  const pitchAngleDegrees = (tangentAngle * 180.0) / Math.PI;
-
-  // Calculate wheel travel
+  const shockLength = distance(finalFrameMount, swingarmEyePos);
   const wheelTravel = Math.abs(geometry.bbHeight - bbY);
 
-  // Calculate shock length with adjusted frame position
-  const shockLength = distance(finalFrameMount, swingarmEyePos);
-
-  const state: KinematicStateFirstPass = {
+  return {
     travelMM: wheelTravel,
     rearAxlePosition: rearAxlePos,
     bbPosition: bbPos,
     pivotPosition: pivotPos,
     swingarmEyePosition: swingarmEyePos,
     shockLength,
-    pitchAngleDegrees,
   };
-
-  return state;
 }
 
-export const getIdlerPosition = (
-  state: KinematicState,
+// Internal helper: resolves idler position from raw world-frame points.
+// Used both during KinematicState construction and via the public getIdlerPosition.
+function idlerPositionFromWorld(
+  bbPos: Point2D,
+  pivotPos: Point2D,
+  rearAxlePos: Point2D,
   geometry: BikeGeometry,
-): Point2D | null => {
+): Point2D | null {
   if (geometry.idlerType === IdlerType.None) {
     return null;
   } else if (geometry.idlerType === IdlerType.FrameMounted) {
-    return Point2D.add(state.bbPosition, {
-      x: geometry.idlerX,
-      y: geometry.idlerY,
-    });
+    return Point2D.add(bbPos, { x: geometry.idlerX, y: geometry.idlerY });
   } else {
     // Swingarm-mounted idler
     const rearWheelRadius = computedProperties.rearWheelRadius(geometry);
@@ -440,7 +351,6 @@ export const getIdlerPosition = (
       x: geometry.bbToPivotX,
       y: geometry.bbHeight + geometry.bbToPivotY,
     };
-
     const topOutPivotToAxleVertDist = rearWheelRadius - topOutPivot.y;
     const topOutPivotToAxleHorizDist = Math.sqrt(
       geometry.swingarmLength * geometry.swingarmLength -
@@ -454,50 +364,59 @@ export const getIdlerPosition = (
       topOutPivot,
       topOutAxle,
       topOutIdler,
-      state.pivotPosition,
-      state.rearAxlePosition,
+      pivotPos,
+      rearAxlePos,
     );
   }
-};
+}
 
-const getFrontSprocketCircle = (
+export const getIdlerPosition = (
   state: KinematicState,
   geometry: BikeGeometry,
-): Circle => {
-  if (
-    geometry.idlerType === IdlerType.None ||
-    geometry.idlerType === IdlerType.SwingarmMounted
-  ) {
-    const center = Point2D.add(state.bbPosition, {
+): Point2D | null => {
+  return idlerPositionFromWorld(
+    state.bb.world,
+    state.pivot.world,
+    state.rearAxle.world,
+    geometry,
+  );
+};
+
+function getFrontSprocketCircle(
+  bbPos: Point2D,
+  pivotPos: Point2D,
+  rearAxlePos: Point2D,
+  geometry: BikeGeometry,
+): Circle {
+  if (geometry.idlerType === IdlerType.None) {
+    const center = Point2D.add(bbPos, {
       x: geometry.chainringOffsetX,
       y: geometry.chainringOffsetY,
     });
-    const radius = sprocketRadius(geometry.chainringTeeth);
-    return { center, radius };
+    return { center, radius: sprocketRadius(geometry.chainringTeeth) };
   } else {
     const radius = sprocketRadius(geometry.idlerTeeth);
-    const center = getIdlerPosition(state, geometry)!;
+    const center = idlerPositionFromWorld(bbPos, pivotPos, rearAxlePos, geometry)!;
     return { center, radius };
   }
-};
+}
 
-const getRearSprocketCircle = (
-  state: KinematicState,
+function getRearSprocketCircle(
+  bbPos: Point2D,
+  pivotPos: Point2D,
+  rearAxlePos: Point2D,
   geometry: BikeGeometry,
-): Circle => {
+): Circle {
   if (
     geometry.idlerType === IdlerType.None ||
     geometry.idlerType === IdlerType.FrameMounted
   ) {
-    const center = state.rearAxlePosition;
-    const radius = sprocketRadius(geometry.cogTeeth);
-    return { center, radius };
+    return { center: rearAxlePos, radius: sprocketRadius(geometry.cogTeeth) };
   } else {
-    const center = getIdlerPosition(state, geometry)!;
-    const radius = sprocketRadius(geometry.idlerTeeth);
-    return { center, radius };
+    const center = idlerPositionFromWorld(bbPos, pivotPos, rearAxlePos, geometry)!;
+    return { center, radius: sprocketRadius(geometry.idlerTeeth) };
   }
-};
+}
 
 export const getApplyPitchRotation =
   (rearAxle: Point2D, pitchAngleDegrees: number) => (point: Point2D) => {
@@ -518,13 +437,14 @@ export function getRotatedCentreOfMass(
   applyPitchRotation: (p: Point2D) => Point2D,
 ): Point2D {
   return applyPitchRotation(
-    Point2D.add(state.bbPosition, {
+    Point2D.add(state.bb.world, {
       x: geometry.comX,
       y: geometry.comY,
     }),
   );
 }
 
+// ---- Anti-squat types (exported for Calculations.tsx) ----
 type AntiSquatStep1 = {
   chainForce: LineSegment;
   suspensionForce: LineSegment;
@@ -537,31 +457,31 @@ type AntiSquatFinal = AntiSquatStep2 & {
   antiSquatIntersection: Point2D;
   centreOfMassHeight: number;
 };
-
 type AntiSquatCalculations = AntiSquatStep1 | AntiSquatStep2 | AntiSquatFinal;
 
-export const doAntiSquatCalculations = (
-  state: KinematicState,
+// Internal: shared anti-squat computation using raw world-frame points + pre-built applyPitchRotation
+function computeAntiSquatSteps(
+  bbPos: Point2D,
+  pivotPos: Point2D,
+  rearAxlePos: Point2D,
+  frontAxlePos: Point2D,
+  applyPitchRotation: (p: Point2D) => Point2D,
   geometry: BikeGeometry,
-  {
-    sprocketTangent = true,
-    warn = false,
-  }: { sprocketTangent?: boolean; warn?: boolean } = {},
-): AntiSquatCalculations => {
-  const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxlePosition,
-    state.pitchAngleDegrees,
-  );
-  const frontSprocket = getFrontSprocketCircle(state, geometry);
+  opts: { sprocketTangent?: boolean; warn?: boolean } = {},
+): AntiSquatCalculations {
+  const { sprocketTangent = true, warn = false } = opts;
+
+  const frontSprocket = getFrontSprocketCircle(bbPos, pivotPos, rearAxlePos, geometry);
   const frontSprocketRotated = {
     center: applyPitchRotation(frontSprocket.center),
     radius: frontSprocket.radius,
   };
-  const rearSprocket = getRearSprocketCircle(state, geometry);
+  const rearSprocket = getRearSprocketCircle(bbPos, pivotPos, rearAxlePos, geometry);
   const rearSprocketRotated = {
     center: applyPitchRotation(rearSprocket.center),
     radius: rearSprocket.radius,
   };
+
   const { start: chainlineStart, end: chainlineEnd } = sprocketTangent
     ? tangentPoints(
         frontSprocketRotated.center,
@@ -571,19 +491,21 @@ export const doAntiSquatCalculations = (
       )
     : { start: frontSprocketRotated.center, end: rearSprocketRotated.center };
 
-  const instantCenter = applyPitchRotation(state.pivotPosition);
-  const rearAxleRotated = applyPitchRotation(state.rearAxlePosition);
-  const frontAxleRotated = applyPitchRotation(state.frontAxlePosition);
+  const instantCenter = applyPitchRotation(pivotPos);
+  const rearAxleRotated = applyPitchRotation(rearAxlePos);
+  const frontAxleRotated = applyPitchRotation(frontAxlePos);
   const instantForceCenter = lineIntersection(
     chainlineStart,
     chainlineEnd,
     instantCenter,
     rearAxleRotated,
   );
+
   const calculations: AntiSquatStep1 = {
     chainForce: { start: chainlineStart, end: chainlineEnd },
     suspensionForce: { start: instantCenter, end: rearAxleRotated },
   };
+
   if (!instantForceCenter) {
     if (warn)
       console.warn(
@@ -599,6 +521,7 @@ export const doAntiSquatCalculations = (
     instantForceLine: { start: instantForceCenter, end: rearContactPatch },
     frontContactPatch: { x: frontAxleRotated.x, y: 0 },
   };
+
   const antiSquatIntersection = lineIntersectionWithVertical(
     rearContactPatch,
     instantForceCenter,
@@ -609,10 +532,8 @@ export const doAntiSquatCalculations = (
     return calculations2;
   }
 
-  const centreOfMassHeight = getRotatedCentreOfMass(
-    state,
-    geometry,
-    applyPitchRotation,
+  const centreOfMassHeight = applyPitchRotation(
+    Point2D.add(bbPos, { x: geometry.comX, y: geometry.comY }),
   ).y;
 
   return {
@@ -620,37 +541,59 @@ export const doAntiSquatCalculations = (
     centreOfMassHeight,
     antiSquatIntersection,
   } satisfies AntiSquatFinal;
+}
+
+// Exported: used by Calculations.tsx to display anti-squat force lines
+export const doAntiSquatCalculations = (
+  state: KinematicState,
+  geometry: BikeGeometry,
+  opts: { sprocketTangent?: boolean; warn?: boolean } = {},
+): AntiSquatCalculations => {
+  const applyPitchRotation = getApplyPitchRotation(
+    state.rearAxle.world,
+    state.pitchAngleDegrees,
+  );
+  return computeAntiSquatSteps(
+    state.bb.world,
+    state.pivot.world,
+    state.rearAxle.world,
+    state.frontAxle.world,
+    applyPitchRotation,
+    geometry,
+    opts,
+  );
 };
 
 function calculateVisualAntiSquat(
-  state: KinematicState,
+  fp: FirstPassState,
+  frontAxlePos: Point2D,
   geometry: BikeGeometry,
-  { sprocketTangent = true }: { sprocketTangent?: boolean } = {},
+  applyPitchRotation: (p: Point2D) => Point2D,
+  opts: { sprocketTangent?: boolean } = {},
 ): number {
-  const calculations = doAntiSquatCalculations(state, geometry, {
-    sprocketTangent,
-    warn: false,
-  });
-  if (!("antiSquatIntersection" in calculations)) {
-    return 0;
-  }
+  const calculations = computeAntiSquatSteps(
+    fp.bbPosition,
+    fp.pivotPosition,
+    fp.rearAxlePosition,
+    frontAxlePos,
+    applyPitchRotation,
+    geometry,
+    opts,
+  );
+  if (!("antiSquatIntersection" in calculations)) return 0;
   const { antiSquatIntersection, centreOfMassHeight } = calculations;
   return (antiSquatIntersection.y / centreOfMassHeight) * 100;
 }
 
 function calculateVisualAntiRise(
-  state: KinematicState,
+  fp: FirstPassState,
+  frontAxlePos: Point2D,
   geometry: BikeGeometry,
+  applyPitchRotation: (p: Point2D) => Point2D,
 ): number {
-  
-  const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxlePosition,
-    state.pitchAngleDegrees,
-  );
-
-  const instantCenter = applyPitchRotation(state.pivotPosition);
-  const rearAxleRotated = applyPitchRotation(state.rearAxlePosition);
-  const frontAxleRotated = applyPitchRotation(state.frontAxlePosition);
+  const instantCenter = applyPitchRotation(fp.pivotPosition);
+  const rearAxleRotated = applyPitchRotation(fp.rearAxlePosition);
+  const frontAxleRotated = applyPitchRotation(frontAxlePos);
 
   const antiriseIntersection = lineIntersectionWithVertical(
     rearAxleRotated,
@@ -665,31 +608,22 @@ function calculateVisualAntiRise(
     });
     return 0;
   }
-  const centreOfMassHeight = getRotatedCentreOfMass(
-    state,
-    geometry,
-    applyPitchRotation,
-  ).y;
 
+  const centreOfMassHeight = applyPitchRotation(
+    Point2D.add(fp.bbPosition, { x: geometry.comX, y: geometry.comY }),
+  ).y;
   return (antiriseIntersection.y / centreOfMassHeight) * 100;
 }
 
-function computeTrail(state: KinematicState, geometry: BikeGeometry): number {
-  // Calculate perpendicular distance from contact patch to head tube line (in screen/pitch-rotated space)
-  const contactPatch = { x: state.frontAxlePosition.x, y: 0 };
-  const applyPitchRotation = getApplyPitchRotation(
-    state.rearAxlePosition,
-    state.pitchAngleDegrees,
-  );
-
-  const headtubeTop = computedProperties.headTubeTop(
-    geometry,
-    state.bbPosition,
-  );
-  const headtubeBottom = computedProperties.headTubeBottom(
-    geometry,
-    state.bbPosition,
-  );
+function computeTrail(
+  fp: FirstPassState,
+  frontAxlePos: Point2D,
+  geometry: BikeGeometry,
+  applyPitchRotation: (p: Point2D) => Point2D,
+): number {
+  const contactPatch = { x: frontAxlePos.x, y: 0 };
+  const headtubeTop = computedProperties.headTubeTop(geometry, fp.bbPosition);
+  const headtubeBottom = computedProperties.headTubeBottom(geometry, fp.bbPosition);
   const htTopRotated = applyPitchRotation(headtubeTop);
   const htBottomRotated = applyPitchRotation(headtubeBottom);
 
@@ -698,9 +632,6 @@ function computeTrail(state: KinematicState, geometry: BikeGeometry): number {
     htVector.y * (contactPatch.x - htTopRotated.x) -
       htVector.x * (contactPatch.y - htTopRotated.y),
   );
-  const denominator = Math.sqrt(
-    htVector.x * htVector.x + htVector.y * htVector.y,
-  );
+  const denominator = Math.sqrt(htVector.x * htVector.x + htVector.y * htVector.y);
   return numerator / denominator;
 }
-

--- a/lib/kinematics.ts
+++ b/lib/kinematics.ts
@@ -664,7 +664,8 @@ function computeTrail(
   geometry: BikeGeometry,
   applyPitchRotation: (p: Point2D) => Point2D,
 ): number {
-  const contactPatch = { x: frontAxlePos.x, y: 0 };
+  const frontAxleRotated = applyPitchRotation(frontAxlePos);
+  const contactPatch = { x: frontAxleRotated.x, y: 0 };
   const headtubeTop = computedProperties.headTubeTop(geometry, fp.bbPosition);
   const headtubeBottom = computedProperties.headTubeBottom(geometry, fp.bbPosition);
   const htTopRotated = applyPitchRotation(headtubeTop);

--- a/lib/kinematics.ts
+++ b/lib/kinematics.ts
@@ -3,6 +3,7 @@ import {
   BikeGeometry,
   KinematicState,
   KinematicPoint,
+  BikeState,
   AnalysisResults,
   Point2D,
   computedProperties,
@@ -19,6 +20,7 @@ import {
   tangentPoints,
   lineIntersection,
   lineIntersectionWithVertical,
+  degreesToRadians,
 } from "./geometry";
 
 interface RigidTriangle {
@@ -56,8 +58,8 @@ export function runKinematicAnalysis(geometry: BikeGeometry): AnalysisResults {
     firstPassStates.push({ ...state, proportionalForkStroke });
   }
 
-  // Second pass: build full KinematicState with no dummy initialisation
-  const states: KinematicState[] = [];
+  // Second pass: build full BikeState with no dummy initialisation
+  const states: BikeState[] = [];
   const axlePath: Point2D[] = [];
   const frontAxlePath: Point2D[] = [];
 
@@ -123,7 +125,40 @@ export function runKinematicAnalysis(geometry: BikeGeometry): AnalysisResults {
     const antiRise = calculateVisualAntiRise(fp, frontAxlePos, geometry, applyPitchRotation);
     const trail = computeTrail(fp, frontAxlePos, geometry, applyPitchRotation);
 
-    const state: KinematicState = {
+    // Geometry-derived positions
+    const headTubeTopWorld = computedProperties.headTubeTop(geometry, fp.bbPosition);
+    const headTubeBottomWorld = computedProperties.headTubeBottom(geometry, fp.bbPosition);
+    const seatAngleRad = degreesToRadians(geometry.seatAngle);
+    const seatTopWorld: Point2D = {
+      x: fp.bbPosition.x - geometry.seatTubeLength * Math.cos(seatAngleRad),
+      y: fp.bbPosition.y + geometry.seatTubeLength * Math.sin(seatAngleRad),
+    };
+    const cosHT = Math.cos(htaRad);
+    const sinHT = Math.sin(htaRad);
+    const forkBendWorld: Point2D = {
+      x: headTubeBottomWorld.x + effectiveForkLength * cosHT,
+      y: headTubeBottomWorld.y - effectiveForkLength * sinHT,
+    };
+    const shockFrameMountWorld: Point2D = {
+      x: fp.bbPosition.x + geometry.shockFrameMountX,
+      y: fp.bbPosition.y + geometry.shockFrameMountY,
+    };
+    const chainringCenterWorld: Point2D = {
+      x: fp.bbPosition.x + geometry.chainringOffsetX,
+      y: fp.bbPosition.y + geometry.chainringOffsetY,
+    };
+    const idlerWorld = idlerPositionFromWorld(
+      fp.bbPosition,
+      fp.pivotPosition,
+      fp.rearAxlePosition,
+      geometry,
+    );
+    const centreOfMassWorld: Point2D = {
+      x: fp.bbPosition.x + geometry.comX,
+      y: fp.bbPosition.y + geometry.comY,
+    };
+
+    const state: BikeState = {
       travelMM: fp.travelMM,
       shockLength: fp.shockLength,
       pitchAngleDegrees,
@@ -142,6 +177,14 @@ export function runKinematicAnalysis(geometry: BikeGeometry): AnalysisResults {
       totalChainGrowth: 0,
       trail,
       crankAngle: 0,
+      headTubeTop: toKP(headTubeTopWorld),
+      headTubeBottom: toKP(headTubeBottomWorld),
+      seatTop: toKP(seatTopWorld),
+      forkBend: toKP(forkBendWorld),
+      shockFrameMount: toKP(shockFrameMountWorld),
+      chainringCenter: toKP(chainringCenterWorld),
+      idler: idlerWorld ? toKP(idlerWorld) : null,
+      centreOfMass: toKP(centreOfMassWorld),
     };
 
     states.push(state);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -173,8 +173,23 @@ export interface KinematicState {
   crankAngle: number;       // unimplemented, always 0
 }
 
+// Extends KinematicState with geometry-derived positions, computed once per state
+export interface BikeState extends KinematicState {
+  // Frame tube endpoints
+  headTubeTop: KinematicPoint;
+  headTubeBottom: KinematicPoint;
+  seatTop: KinematicPoint;
+  forkBend: KinematicPoint; // end of stanchions (before axle offset)
+
+  // Component positions
+  shockFrameMount: KinematicPoint;
+  chainringCenter: KinematicPoint;
+  idler: KinematicPoint | null;
+  centreOfMass: KinematicPoint;
+}
+
 export interface AnalysisResults {
-  states: KinematicState[];
+  states: BikeState[];
   axlePath: Point2D[];
   frontAxlePath: Point2D[];
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -142,39 +142,35 @@ export function createDefaultGeometry({
   };
 }
 
-// First pass: kinematic state calculated from shock stroke only
-export interface KinematicStateFirstPass {
-  travelMM: number;
-  rearAxlePosition: Point2D;
-  bbPosition: Point2D;
-  pivotPosition: Point2D;
-  swingarmEyePosition: Point2D;
-  shockLength: number;
-  pitchAngleDegrees: number;
+// A position stored in both the kinematic ground frame and the pitch-rotated frame
+export interface KinematicPoint {
+  world: Point2D;          // Kinematic ground frame (Y=0 is ground, rear wheel at Y=rearWheelRadius)
+  wheelsOnGround: Point2D; // Pitch-rotated around rear axle (both contact patches level)
 }
 
-// Complete kinematic state (first pass + second pass calculations)
-export interface KinematicState extends KinematicStateFirstPass {
-  // Geometry - calculated in second pass (front axle and pitch-dependent values)
-  frontAxlePosition: Point2D;
+export interface KinematicState {
+  travelMM: number;
+  shockLength: number;
+  pitchAngleDegrees: number;
   forkCompression: number;
 
-  // Dynamics - calculated in second pass (derivatives and derived values)
+  // Key frame positions in both coordinate systems
+  rearAxle: KinematicPoint;
+  frontAxle: KinematicPoint;
+  bb: KinematicPoint;
+  pivot: KinematicPoint;
+  swingarmEye: KinematicPoint;
+
+  // Dynamics
   leverageRatio: number;
   wheelRate: number;
   antiSquat: number;
   antiRise: number;
-
-  // Drivetrain - calculated in second pass
-  pedalKickback: number;
-  chainGrowth: number;
-  totalChainGrowth: number;
-
-  // Trail - calculated in second pass (depends on pitch rotation)
+  pedalKickback: number;    // unimplemented, always 0
+  chainGrowth: number;      // unimplemented, always 0
+  totalChainGrowth: number; // unimplemented, always 0
   trail: number;
-
-  // Crank angle - calculated from pedal kickback
-  crankAngle: number;
+  crankAngle: number;       // unimplemented, always 0
 }
 
 export interface AnalysisResults {


### PR DESCRIPTION
Introduces KinematicPoint { world, wheelsOnGround } so each named position
in KinematicState carries both the kinematic ground frame and pitch-rotated
frame coordinates, computed once in the engine rather than per render.

- Remove exported KinematicStateFirstPass (now internal to kinematics.ts)
- Replace flat rearAxlePosition/bbPosition/etc. fields with rearAxle/bb/etc.
  KinematicPoint fields on KinematicState
- Eliminate dummy-zero initialisation in runKinematicAnalysis: all values are
  computed into locals then the state object is constructed once with no mutation
- Extract idlerPositionFromWorld private helper to avoid constructing KinematicState
  before it is ready
- Helper functions (antiSquat, antiRise, trail) now accept applyPitchRotation as
  a parameter instead of re-creating it internally
- Visualization components use state.rearAxle.wheelsOnGround etc. directly,
  removing redundant per-component pitch rotation calls for named positions

https://claude.ai/code/session_01GMTxDFpSX2Xw3y2ZJeTKQb