### PR TITLE
Add independent fork and shock compression controls with coupling toggle

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useBikeViewModel } from "@/hooks/useBikeViewModel";
 import { InputPanel } from "@/components/InputPanel";
 import { AnimationView } from "@/components/Visualization";
 import { GraphPanel } from "@/components/Graphs";
 import { Attribution } from "@/components/Attribution";
+import { runKinematicAnalysis } from "@/lib/kinematics";
+import { AnalysisResults } from "@/lib/types";
 
 type MobileTab = "inputs" | "bike" | "analysis";
 
@@ -13,6 +15,32 @@ export default function Home() {
   const viewModel = useBikeViewModel();
   const [isAnimating, setIsAnimating] = useState(false);
   const [mobileTab, setMobileTab] = useState<MobileTab>("bike");
+
+  // Fork / shock coupling state (lifted so GraphPanel can receive fork-aware results)
+  const [forkCompressionPercent, setForkCompressionPercent] = useState(0);
+  const [coupled, setCoupled] = useState(true);
+  const [graphResults, setGraphResults] = useState<AnalysisResults>(
+    viewModel.analysisResults,
+  );
+
+  // Recompute graph results whenever fork compression or geometry changes.
+  // When coupled, the proportional analysis already in the viewModel is correct.
+  // When uncoupled, re-run with the fixed fork compression so that all metrics
+  // (trail, anti-squat, anti-rise, pitch angle, …) match what the animation shows.
+  useEffect(() => {
+    if (coupled) {
+      setGraphResults(viewModel.analysisResults);
+      return;
+    }
+    const timer = setTimeout(() => {
+      const fixedForkMM =
+        (forkCompressionPercent / 100) * viewModel.geometry.forkTravel;
+      setGraphResults(
+        runKinematicAnalysis(viewModel.geometry, fixedForkMM),
+      );
+    }, 100);
+    return () => clearTimeout(timer);
+  }, [forkCompressionPercent, coupled, viewModel.analysisResults, viewModel.geometry]);
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -151,6 +179,10 @@ export default function Home() {
               animationSpeed={viewModel.animationSpeed}
               selectedGraph={viewModel.selectedGraph}
               showCalculations={true}
+              forkCompressionPercent={forkCompressionPercent}
+              coupled={coupled}
+              onForkCompressionChange={setForkCompressionPercent}
+              onCoupledChange={setCoupled}
             />
           </div>
 
@@ -161,7 +193,7 @@ export default function Home() {
             }`}
           >
             <GraphPanel
-              results={viewModel.analysisResults}
+              results={graphResults}
               selectedGraph={viewModel.selectedGraph}
               onGraphChange={viewModel.setSelectedGraph}
               travelPercentage={travelPercentage}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,28 +19,28 @@ export default function Home() {
   // Fork / shock coupling state (lifted so GraphPanel can receive fork-aware results)
   const [forkCompressionPercent, setForkCompressionPercent] = useState(0);
   const [coupled, setCoupled] = useState(true);
-  const [graphResults, setGraphResults] = useState<AnalysisResults>(
-    viewModel.analysisResults,
-  );
+  // Only stores the uncoupled (fixed-fork) analysis; null means "not yet computed".
+  const [forkAwareResults, setForkAwareResults] = useState<AnalysisResults | null>(null);
 
-  // Recompute graph results whenever fork compression or geometry changes.
-  // When coupled, the proportional analysis already in the viewModel is correct.
-  // When uncoupled, re-run with the fixed fork compression so that all metrics
-  // (trail, anti-squat, anti-rise, pitch angle, …) match what the animation shows.
+  // When uncoupled, re-run the analysis with the fixed fork compression so that
+  // all metrics (trail, anti-squat, anti-rise, pitch angle, …) match the animation.
   useEffect(() => {
-    if (coupled) {
-      setGraphResults(viewModel.analysisResults);
-      return;
-    }
+    if (coupled) return;
     const timer = setTimeout(() => {
       const fixedForkMM =
         (forkCompressionPercent / 100) * viewModel.geometry.forkTravel;
-      setGraphResults(
+      setForkAwareResults(
         runKinematicAnalysis(viewModel.geometry, fixedForkMM),
       );
     }, 100);
     return () => clearTimeout(timer);
   }, [forkCompressionPercent, coupled, viewModel.analysisResults, viewModel.geometry]);
+
+  // When coupled, use the proportional results directly; when uncoupled, use the
+  // fork-aware results (falling back to proportional until the first debounce fires).
+  const graphResults = coupled
+    ? viewModel.analysisResults
+    : (forkAwareResults ?? viewModel.analysisResults);
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/components/Visualization.tsx
+++ b/components/Visualization.tsx
@@ -148,47 +148,61 @@ type AnimationViewProps = Omit<VisualizationProps, "travelPercentage" | "forkCom
   initialTravelPercentage: number;
   isAnimating: boolean;
   animationSpeed: number;
+  /** Controlled: current fork compression percentage (0-100) */
+  forkCompressionPercent: number;
+  /** Controlled: whether fork and shock move together */
+  coupled: boolean;
+  onForkCompressionChange: (percent: number) => void;
+  onCoupledChange: (coupled: boolean) => void;
 };
 
 export function AnimationView({
   initialTravelPercentage,
   isAnimating,
   animationSpeed,
+  forkCompressionPercent,
+  coupled,
+  onForkCompressionChange,
+  onCoupledChange,
   ...props
 }: AnimationViewProps) {
   const axlePath = props.analysisResults.states.map((s) => s.rearAxle.world);
+  // Shock position is kept local — it drives animation independently of fork
   const [shockPercent, setShockPercent] = React.useState(initialTravelPercentage);
-  const [forkPercent, setForkPercent] = React.useState(initialTravelPercentage);
-  const [coupled, setCoupled] = React.useState(true);
 
   React.useEffect(() => {
     if (!isAnimating) return;
     const interval = setInterval(() => {
       setShockPercent((prev) => {
         const next = prev + 0.5 * animationSpeed;
-        const newVal = next > 100 ? 0 : next;
-        if (coupled) setForkPercent(newVal);
-        return newVal;
+        return next > 100 ? 0 : next;
       });
     }, 50);
     return () => clearInterval(interval);
-  }, [isAnimating, animationSpeed, coupled]);
+  }, [isAnimating, animationSpeed]);
 
   const handleShockChange = (value: number) => {
     setShockPercent(value);
-    if (coupled) setForkPercent(value);
+    if (coupled) onForkCompressionChange(value);
   };
 
   const handleCoupledChange = (checked: boolean) => {
-    setCoupled(checked);
-    if (checked) setForkPercent(shockPercent);
+    onCoupledChange(checked);
+    if (!checked) {
+      // Initialise fork at current shock position when uncoupling
+      onForkCompressionChange(shockPercent);
+    }
   };
+
+  // When coupled, the visual fork follows shock; when uncoupled it follows the
+  // controlled forkCompressionPercent.
+  const effectiveForkPercent = coupled ? shockPercent : forkCompressionPercent;
 
   return (
     <div className="flex flex-col h-full bg-gray-50 dark:bg-black">
       <BikeVisualization
         travelPercentage={shockPercent}
-        forkCompressionPercent={forkPercent}
+        forkCompressionPercent={effectiveForkPercent}
         {...props}
         axlePath={axlePath}
       />
@@ -237,13 +251,13 @@ export function AnimationView({
             min="0"
             max="100"
             step="0.5"
-            value={forkPercent}
-            onChange={(e) => setForkPercent(parseFloat(e.target.value))}
+            value={forkCompressionPercent}
+            onChange={(e) => onForkCompressionChange(parseFloat(e.target.value))}
             disabled={coupled}
             className="flex-1 h-2 bg-gray-300 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
           />
           <span className="text-sm font-mono text-gray-600 dark:text-gray-400 w-12 text-right">
-            {forkPercent.toFixed(1)}%
+            {forkCompressionPercent.toFixed(1)}%
           </span>
         </div>
       </div>

--- a/components/Visualization.tsx
+++ b/components/Visualization.tsx
@@ -8,6 +8,7 @@ import {
   getScreenConversions,
   Point2D,
 } from "@/lib/types";
+import { overrideForkCompression } from "@/lib/kinematics";
 import { GroundLine } from "./visualization/GroundLine";
 import { FrontTriangle } from "./visualization/FrontTriangle";
 import { Swingarm } from "./visualization/Swingarm";
@@ -25,7 +26,8 @@ type VisualizationProps = {
   geometry: BikeGeometry;
   analysisResults: AnalysisResults;
   axlePath?: Point2D[];
-  travelPercentage: number; // 0-100
+  travelPercentage: number; // 0-100, controls rear shock
+  forkCompressionPercent?: number; // 0-100, overrides fork independently
   selectedGraph?: string;
   showCalculations?: boolean;
 };
@@ -34,6 +36,7 @@ export function BikeVisualization({
   geometry,
   analysisResults,
   travelPercentage,
+  forkCompressionPercent,
   selectedGraph,
   axlePath,
   showCalculations = false,
@@ -49,10 +52,20 @@ export function BikeVisualization({
   const stateIndex = Math.floor(
     (travelPercentage / 100) * (analysisResults.states.length - 1),
   );
-  const state =
+  const rawState =
     analysisResults.states[
       Math.max(0, Math.min(stateIndex, analysisResults.states.length - 1))
     ];
+
+  // Override fork positions when an independent fork compression is provided
+  const state =
+    forkCompressionPercent !== undefined
+      ? overrideForkCompression(
+          rawState,
+          (forkCompressionPercent / 100) * geometry.forkTravel,
+          geometry,
+        )
+      : rawState;
 
   const rearAxleWorld = state.rearAxle.world;
   const frontAxleWorld = state.frontAxle.world;
@@ -131,7 +144,7 @@ export function BikeVisualization({
   );
 }
 
-type AnimationViewProps = Omit<VisualizationProps, "travelPercentage"> & {
+type AnimationViewProps = Omit<VisualizationProps, "travelPercentage" | "forkCompressionPercent"> & {
   initialTravelPercentage: number;
   isAnimating: boolean;
   animationSpeed: number;
@@ -144,46 +157,93 @@ export function AnimationView({
   ...props
 }: AnimationViewProps) {
   const axlePath = props.analysisResults.states.map((s) => s.rearAxle.world);
-  const [animProgress, setAnimProgress] = React.useState(
-    initialTravelPercentage,
-  );
+  const [shockPercent, setShockPercent] = React.useState(initialTravelPercentage);
+  const [forkPercent, setForkPercent] = React.useState(initialTravelPercentage);
+  const [coupled, setCoupled] = React.useState(true);
 
   React.useEffect(() => {
     if (!isAnimating) return;
-
     const interval = setInterval(() => {
-      setAnimProgress((prev) => {
+      setShockPercent((prev) => {
         const next = prev + 0.5 * animationSpeed;
-        return next > 100 ? 0 : next;
+        const newVal = next > 100 ? 0 : next;
+        if (coupled) setForkPercent(newVal);
+        return newVal;
       });
     }, 50);
-
     return () => clearInterval(interval);
-  }, [isAnimating, animationSpeed]);
+  }, [isAnimating, animationSpeed, coupled]);
+
+  const handleShockChange = (value: number) => {
+    setShockPercent(value);
+    if (coupled) setForkPercent(value);
+  };
+
+  const handleCoupledChange = (checked: boolean) => {
+    setCoupled(checked);
+    if (checked) setForkPercent(shockPercent);
+  };
 
   return (
     <div className="flex flex-col h-full bg-gray-50 dark:bg-black">
       <BikeVisualization
-        travelPercentage={animProgress}
+        travelPercentage={shockPercent}
+        forkCompressionPercent={forkPercent}
         {...props}
         axlePath={axlePath}
       />
-      <div className="p-4 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800">
-        <div className="flex items-center gap-4">
-          <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-            Travel
+      <div className="p-4 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800 space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            Compression
+          </span>
+          <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={coupled}
+              onChange={(e) => handleCoupledChange(e.target.checked)}
+              className="w-4 h-4"
+            />
+            Couple fork &amp; shock
           </label>
+        </div>
+
+        {/* Shock slider */}
+        <div className="flex items-center gap-3">
+          <span className="text-xs font-medium text-gray-500 dark:text-gray-400 w-10 text-right">
+            Shock
+          </span>
           <input
             type="range"
             min="0"
             max="100"
             step="0.5"
-            value={animProgress}
-            onChange={(e) => setAnimProgress(parseFloat(e.target.value))}
+            value={shockPercent}
+            onChange={(e) => handleShockChange(parseFloat(e.target.value))}
             className="flex-1 h-2 bg-gray-300 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer"
           />
-          <span className="text-sm font-mono text-gray-600 dark:text-gray-400 w-12">
-            {animProgress.toFixed(1)}%
+          <span className="text-sm font-mono text-gray-600 dark:text-gray-400 w-12 text-right">
+            {shockPercent.toFixed(1)}%
+          </span>
+        </div>
+
+        {/* Fork slider */}
+        <div className="flex items-center gap-3">
+          <span className="text-xs font-medium text-gray-500 dark:text-gray-400 w-10 text-right">
+            Fork
+          </span>
+          <input
+            type="range"
+            min="0"
+            max="100"
+            step="0.5"
+            value={forkPercent}
+            onChange={(e) => setForkPercent(parseFloat(e.target.value))}
+            disabled={coupled}
+            className="flex-1 h-2 bg-gray-300 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+          />
+          <span className="text-sm font-mono text-gray-600 dark:text-gray-400 w-12 text-right">
+            {forkPercent.toFixed(1)}%
           </span>
         </div>
       </div>

--- a/lib/kinematics.test.ts
+++ b/lib/kinematics.test.ts
@@ -259,6 +259,36 @@ describe("Anti-Squat and Anti-Rise", () => {
       expect(state.antiRise).toBeLessThan(200);
     }
   });
+
+  describe("with swingarm-mounted idler", () => {
+    // Regression test: getFrontSprocketCircle used to return the idler for both
+    // FrameMounted and SwingarmMounted, making the two circles identical.
+    // tangentPoints(idler, idler) divides by dist=0 → NaN antiSquat.
+    const geometry = createDefaultGeometry({
+      overrides: {
+        idlerType: IdlerType.SwingarmMounted,
+        idlerX: -60,
+        idlerY: 160,
+        idlerTeeth: 16,
+      },
+    });
+
+    it("anti-squat is finite (not NaN) for all travel states", () => {
+      const results = runKinematicAnalysis(geometry);
+      for (const state of results.states) {
+        expect(isNaN(state.antiSquat)).toBe(false);
+        expect(isFinite(state.antiSquat)).toBe(true);
+      }
+    });
+
+    it("anti-squat is in a physically plausible range (0-1000%)", () => {
+      const results = runKinematicAnalysis(geometry);
+      for (const state of results.states) {
+        expect(state.antiSquat).toBeGreaterThan(0);
+        expect(state.antiSquat).toBeLessThan(1000);
+      }
+    });
+  });
 });
 
 describe("Trail", () => {

--- a/lib/kinematics.ts
+++ b/lib/kinematics.ts
@@ -43,7 +43,19 @@ interface FirstPassState {
   proportionalForkStroke: number;
 }
 
-export function runKinematicAnalysis(geometry: BikeGeometry): AnalysisResults {
+/**
+ * Run a full kinematic sweep across the shock stroke range.
+ *
+ * @param fixedForkCompressionMM  When provided, every state in the sweep uses
+ *   this constant fork compression instead of the proportional value derived
+ *   from shock travel.  Pass this when fork and shock are uncoupled so that
+ *   computed metrics (trail, anti-squat, anti-rise, pitch, …) reflect the
+ *   actual fork position being displayed.
+ */
+export function runKinematicAnalysis(
+  geometry: BikeGeometry,
+  fixedForkCompressionMM?: number,
+): AnalysisResults {
   const rigidTriangle = establishRigidTriangle(geometry);
 
   const stepSize = 0.5; // mm - finer steps for smoother graphs
@@ -54,7 +66,10 @@ export function runKinematicAnalysis(geometry: BikeGeometry): AnalysisResults {
   for (let step = 0; step < strokeSteps; step++) {
     const shockStroke = step * stepSize;
     const travelRatio = shockStroke / geometry.shockStroke;
-    const proportionalForkStroke = travelRatio * geometry.forkTravel;
+    const proportionalForkStroke =
+      fixedForkCompressionMM !== undefined
+        ? fixedForkCompressionMM
+        : travelRatio * geometry.forkTravel;
     const state = calculateStateAtShockStroke(shockStroke, geometry, rigidTriangle);
     firstPassStates.push({ ...state, proportionalForkStroke });
   }

--- a/lib/kinematics.ts
+++ b/lib/kinematics.ts
@@ -591,6 +591,70 @@ export const getApplyPitchRotation =
     };
   };
 
+/**
+ * Re-derives the fork-dependent positions in a BikeState using a new fork
+ * compression value (in mm), recomputing pitch angle and all wheelsOnGround
+ * coordinates accordingly.  Rear-suspension state is left unchanged.
+ */
+export function overrideForkCompression(
+  state: BikeState,
+  forkCompressionMM: number,
+  geometry: BikeGeometry,
+): BikeState {
+  const htaRad = computedProperties.headTubeAngleRadians(geometry);
+  const cosHT = Math.cos(htaRad);
+  const sinHT = Math.sin(htaRad);
+
+  const effectiveForkLength = geometry.forkLength - forkCompressionMM;
+  const headTubeBottomWorld = state.headTubeBottom.world;
+
+  const forkBendWorld: Point2D = {
+    x: headTubeBottomWorld.x + effectiveForkLength * cosHT,
+    y: headTubeBottomWorld.y - effectiveForkLength * sinHT,
+  };
+  const frontAxleWorld: Point2D = {
+    x: headTubeBottomWorld.x + effectiveForkLength * cosHT + geometry.forkOffset * sinHT,
+    y: headTubeBottomWorld.y - effectiveForkLength * sinHT + geometry.forkOffset * cosHT,
+  };
+
+  // Recompute pitch angle from new front axle position
+  const dx = frontAxleWorld.x - state.rearAxle.world.x;
+  const dy = frontAxleWorld.y - state.rearAxle.world.y;
+  const centerDist = Math.sqrt(dx * dx + dy * dy);
+  const centerAngle = Math.atan2(dy, dx);
+  const frontWheelRadius = computedProperties.frontWheelRadius(geometry);
+  const rearWheelRadius = computedProperties.rearWheelRadius(geometry);
+  const radiusDiff = frontWheelRadius - rearWheelRadius;
+  const angleOffset = Math.asin(Math.min(1, Math.max(-1, radiusDiff / centerDist)));
+  const pitchAngleDegrees = ((centerAngle - angleOffset) * 180.0) / Math.PI;
+
+  const applyPitch = getApplyPitchRotation(state.rearAxle.world, pitchAngleDegrees);
+  const toKP = (world: Point2D): KinematicPoint => ({
+    world,
+    wheelsOnGround: applyPitch(world),
+  });
+
+  return {
+    ...state,
+    pitchAngleDegrees,
+    forkCompression: forkCompressionMM,
+    frontAxle: toKP(frontAxleWorld),
+    forkBend: toKP(forkBendWorld),
+    // Re-rotate all other positions with the new pitch
+    rearAxle: toKP(state.rearAxle.world),
+    bb: toKP(state.bb.world),
+    pivot: toKP(state.pivot.world),
+    swingarmEye: toKP(state.swingarmEye.world),
+    headTubeTop: toKP(state.headTubeTop.world),
+    headTubeBottom: toKP(state.headTubeBottom.world),
+    seatTop: toKP(state.seatTop.world),
+    shockFrameMount: toKP(state.shockFrameMount.world),
+    chainringCenter: toKP(state.chainringCenter.world),
+    idler: state.idler ? toKP(state.idler.world) : null,
+    centreOfMass: toKP(state.centreOfMass.world),
+  };
+}
+
 export function getRotatedCentreOfMass(
   state: KinematicState,
   geometry: BikeGeometry,

--- a/lib/kinematics.ts
+++ b/lib/kinematics.ts
@@ -531,16 +531,23 @@ function getFrontSprocketCircle(
   rearAxlePos: Point2D,
   geometry: BikeGeometry,
 ): Circle {
-  if (geometry.idlerType === IdlerType.None) {
+  if (geometry.idlerType === IdlerType.FrameMounted) {
+    // The chainring→idler segment is frame-fixed and does not apply force to the
+    // swingarm.  The idler acts as the effective "front" of the driving segment
+    // (idler → rear cog) that determines anti-squat.
+    const radius = sprocketRadius(geometry.idlerTeeth);
+    const center = idlerPositionFromWorld(bbPos, pivotPos, rearAxlePos, geometry)!;
+    return { center, radius };
+  } else {
+    // No idler: chainring → rear cog.
+    // Swingarm-mounted idler: the idler→cog segment is internal to the swingarm;
+    // the chainring → idler segment is the one that applies force to the swingarm,
+    // so the chainring is the "front" of the driving segment.
     const center = Point2D.add(bbPos, {
       x: geometry.chainringOffsetX,
       y: geometry.chainringOffsetY,
     });
     return { center, radius: sprocketRadius(geometry.chainringTeeth) };
-  } else {
-    const radius = sprocketRadius(geometry.idlerTeeth);
-    const center = idlerPositionFromWorld(bbPos, pivotPos, rearAxlePos, geometry)!;
-    return { center, radius };
   }
 }
 


### PR DESCRIPTION
Introduces separate Shock and Fork sliders in the visualization panel.
When "Couple fork & shock" is checked (default), both sliders move in
sync as before. When uncoupled, fork compression can be set independently
by re-deriving fork positions (frontAxle, forkBend, pitch angle, and all
wheelsOnGround coordinates) from the chosen fork percentage without
re-running the full kinematic sweep.

- lib/kinematics.ts: export overrideForkCompression() which recomputes
  fork-side geometry and re-applies pitch rotation to all KinematicPoints
- components/Visualization.tsx: BikeVisualization accepts optional
  forkCompressionPercent prop and applies the override; AnimationView
  manages shockPercent, forkPercent, and coupled state with two labelled
  range sliders and a coupling checkbox

https://claude.ai/code/session_015bqAUD44wy3FLxFdotGPbT