### PR TITLE
Fix axle path visualization and add Rear Center / Wheel Path graphs

### DIFF
--- a/components/Graphs.tsx
+++ b/components/Graphs.tsx
@@ -8,6 +8,13 @@ interface GraphProps {
   travelPercentage: number;
 }
 
+// Fixed internal coordinate system — SVG scales via viewBox
+const SVG_WIDTH = 800;
+const SVG_HEIGHT = 300;
+const SVG_PADDING = 40;
+const PLOT_WIDTH = SVG_WIDTH - SVG_PADDING * 2;
+const PLOT_HEIGHT = SVG_HEIGHT - SVG_PADDING * 2;
+
 function getGraphData(
   results: AnalysisResults,
   graphType: string,
@@ -42,6 +49,13 @@ function getGraphData(
         y: states.map((s) => s.pedalKickback),
         label: "Pedal Kickback",
         unit: "°",
+      };
+    case GraphType.RearCenter:
+      return {
+        x: states.map((s) => s.travelMM),
+        y: results.axlePath.map((p) => Math.abs(p.x)),
+        label: "Rear Center",
+        unit: "mm",
       };
     case GraphType.ChainGrowth:
       return {
@@ -81,6 +95,213 @@ function getGraphData(
   }
 }
 
+function GridAndAxes() {
+  return (
+    <>
+      <defs>
+        <pattern
+          id="gridMinor"
+          width={PLOT_WIDTH / 10}
+          height={PLOT_HEIGHT / 5}
+          patternUnits="userSpaceOnUse"
+          x={SVG_PADDING}
+          y={SVG_PADDING}
+        >
+          <path
+            d={`M ${PLOT_WIDTH / 10} 0 L 0 0 0 ${PLOT_HEIGHT / 5}`}
+            fill="none"
+            stroke="#e5e7eb"
+            strokeWidth="0.5"
+          />
+        </pattern>
+      </defs>
+      <rect
+        x={SVG_PADDING}
+        y={SVG_PADDING}
+        width={PLOT_WIDTH}
+        height={PLOT_HEIGHT}
+        fill="url(#gridMinor)"
+        opacity="0.3"
+      />
+      <line
+        x1={SVG_PADDING}
+        y1={SVG_HEIGHT - SVG_PADDING}
+        x2={SVG_WIDTH - SVG_PADDING}
+        y2={SVG_HEIGHT - SVG_PADDING}
+        stroke="#333"
+        strokeWidth="2"
+      />
+      <line
+        x1={SVG_PADDING}
+        y1={SVG_PADDING}
+        x2={SVG_PADDING}
+        y2={SVG_HEIGHT - SVG_PADDING}
+        stroke="#333"
+        strokeWidth="2"
+      />
+    </>
+  );
+}
+
+function AxlePathGraph({
+  results,
+  travelPercentage,
+}: {
+  results: AnalysisResults;
+  travelPercentage: number;
+}) {
+  const axlePath = results.axlePath;
+  if (axlePath.length === 0) return null;
+
+  // X axis: distance behind BB (positive = rearward), negate axlePath.x since it is negative
+  // Y axis: height of axle above BB (positive = upward)
+  const xData = axlePath.map((p) => -p.x);
+  const yData = axlePath.map((p) => p.y);
+
+  const xMin = Math.min(...xData);
+  const xMax = Math.max(...xData);
+  const xRange = xMax - xMin || 1;
+  const yMin = Math.min(...yData);
+  const yMax = Math.max(...yData);
+  const yRange = yMax - yMin || 1;
+
+  const scaleX = (v: number) =>
+    ((v - xMin) / xRange) * PLOT_WIDTH + SVG_PADDING;
+  const scaleY = (v: number) =>
+    SVG_HEIGHT - SVG_PADDING - ((v - yMin) / yRange) * PLOT_HEIGHT;
+
+  const pathString = xData
+    .map((x, i) => `${scaleX(x)},${scaleY(yData[i])}`)
+    .join(" ");
+
+  // Current position dot
+  const currentIndex = Math.max(
+    0,
+    Math.min(
+      Math.round((travelPercentage / 100) * (axlePath.length - 1)),
+      axlePath.length - 1,
+    ),
+  );
+  const dotX = scaleX(xData[currentIndex]);
+  const dotY = scaleY(yData[currentIndex]);
+
+  return (
+    <div className="w-full h-full flex flex-col bg-white dark:bg-gray-950">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-800">
+        <h3 className="font-semibold text-gray-900 dark:text-white">
+          Wheel Path (mm)
+        </h3>
+      </div>
+      <div className="flex-1 overflow-hidden flex items-center justify-center p-4">
+        <svg
+          viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
+          width="100%"
+          className="border border-gray-300 dark:border-gray-700 rounded"
+        >
+          <GridAndAxes />
+
+          {/* X axis tick labels */}
+          {[0, 0.25, 0.5, 0.75, 1].map((t, i) => {
+            const x = SVG_PADDING + PLOT_WIDTH * t;
+            const val = xMin + xRange * t;
+            return (
+              <g key={`x-${i}`}>
+                <line
+                  x1={x}
+                  y1={SVG_HEIGHT - SVG_PADDING}
+                  x2={x}
+                  y2={SVG_HEIGHT - SVG_PADDING + 5}
+                  stroke="#333"
+                  strokeWidth="1"
+                />
+                <text
+                  x={x}
+                  y={SVG_HEIGHT - SVG_PADDING + 20}
+                  fontSize="12"
+                  textAnchor="middle"
+                  fill="#666"
+                  className="dark:fill-gray-400"
+                >
+                  {val.toFixed(0)}
+                </text>
+              </g>
+            );
+          })}
+
+          {/* Y axis tick labels */}
+          {[0, 0.25, 0.5, 0.75, 1].map((t, i) => {
+            const y = SVG_HEIGHT - SVG_PADDING - PLOT_HEIGHT * t;
+            const val = yMin + yRange * t;
+            return (
+              <g key={`y-${i}`}>
+                <line
+                  x1={SVG_PADDING - 5}
+                  y1={y}
+                  x2={SVG_PADDING}
+                  y2={y}
+                  stroke="#333"
+                  strokeWidth="1"
+                />
+                <text
+                  x={SVG_PADDING - 10}
+                  y={y + 4}
+                  fontSize="12"
+                  textAnchor="end"
+                  fill="#666"
+                  className="dark:fill-gray-400"
+                >
+                  {val.toFixed(0)}
+                </text>
+              </g>
+            );
+          })}
+
+          {/* Path curve */}
+          <polyline
+            points={pathString}
+            fill="none"
+            stroke="#3b82f6"
+            strokeWidth="2"
+          />
+
+          {/* Current position dot */}
+          <circle
+            cx={dotX}
+            cy={dotY}
+            r={5}
+            fill="#ef4444"
+            opacity="0.85"
+          />
+
+          {/* Axis labels */}
+          <text
+            x={SVG_WIDTH / 2}
+            y={SVG_HEIGHT - 5}
+            fontSize="14"
+            fontWeight="bold"
+            textAnchor="middle"
+            fill="#333"
+            className="dark:fill-gray-300"
+          >
+            Rearward from BB (mm)
+          </text>
+          <text
+            x={12}
+            y={SVG_HEIGHT / 2}
+            fontSize="12"
+            textAnchor="middle"
+            fill="#333"
+            className="dark:fill-gray-300"
+            transform={`rotate(-90, 12, ${SVG_HEIGHT / 2})`}
+          >
+            Upward from BB (mm)
+          </text>
+        </svg>
+      </div>
+    </div>
+  );
+}
+
 export function Graph({
   results,
   selectedGraph,
@@ -94,6 +315,12 @@ export function Graph({
     );
   }
 
+  if (selectedGraph === GraphType.AxlePath) {
+    return (
+      <AxlePathGraph results={results} travelPercentage={travelPercentage} />
+    );
+  }
+
   const graphData = getGraphData(results, selectedGraph);
   const { x: xData, y: yData, label, unit } = graphData;
 
@@ -103,17 +330,10 @@ export function Graph({
   const yRange = yMax - yMin || 1;
   const xMax = Math.max(...xData) || 1;
 
-  // Fixed internal coordinate system — SVG scales via viewBox
-  const width = 800;
-  const height = 300;
-  const padding = 40;
-  const plotWidth = width - padding * 2;
-  const plotHeight = height - padding * 2;
-
   // Scale functions
-  const scaleX = (val: number) => (val / xMax) * plotWidth + padding;
+  const scaleX = (val: number) => (val / xMax) * PLOT_WIDTH + SVG_PADDING;
   const scaleY = (val: number) =>
-    height - padding - ((val - yMin) / yRange) * plotHeight;
+    SVG_HEIGHT - SVG_PADDING - ((val - yMin) / yRange) * PLOT_HEIGHT;
 
   // Find current position
   const currentTravel = (travelPercentage / 100) * xMax;
@@ -132,72 +352,29 @@ export function Graph({
       </div>
       <div className="flex-1 overflow-hidden flex items-center justify-center p-4">
         <svg
-          viewBox={`0 0 ${width} ${height}`}
+          viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
           width="100%"
           className="border border-gray-300 dark:border-gray-700 rounded"
         >
-          {/* Background grid */}
-          <defs>
-            <pattern
-              id="gridMinor"
-              width={plotWidth / 10}
-              height={plotHeight / 5}
-              patternUnits="userSpaceOnUse"
-              x={padding}
-              y={padding}
-            >
-              <path
-                d={`M ${plotWidth / 10} 0 L 0 0 0 ${plotHeight / 5}`}
-                fill="none"
-                stroke="#e5e7eb"
-                strokeWidth="0.5"
-              />
-            </pattern>
-          </defs>
-          <rect
-            x={padding}
-            y={padding}
-            width={plotWidth}
-            height={plotHeight}
-            fill="url(#gridMinor)"
-            opacity="0.3"
-          />
-
-          {/* Axes */}
-          <line
-            x1={padding}
-            y1={height - padding}
-            x2={width - padding}
-            y2={height - padding}
-            stroke="#333"
-            strokeWidth="2"
-          />
-          <line
-            x1={padding}
-            y1={padding}
-            x2={padding}
-            y2={height - padding}
-            stroke="#333"
-            strokeWidth="2"
-          />
+          <GridAndAxes />
 
           {/* X axis labels */}
           {[0, 0.25, 0.5, 0.75, 1].map((t, i) => {
-            const x = padding + plotWidth * t;
+            const x = SVG_PADDING + PLOT_WIDTH * t;
             const val = xMax * t;
             return (
               <g key={`x-${i}`}>
                 <line
                   x1={x}
-                  y1={height - padding}
+                  y1={SVG_HEIGHT - SVG_PADDING}
                   x2={x}
-                  y2={height - padding + 5}
+                  y2={SVG_HEIGHT - SVG_PADDING + 5}
                   stroke="#333"
                   strokeWidth="1"
                 />
                 <text
                   x={x}
-                  y={height - padding + 20}
+                  y={SVG_HEIGHT - SVG_PADDING + 20}
                   fontSize="12"
                   textAnchor="middle"
                   fill="#666"
@@ -211,20 +388,20 @@ export function Graph({
 
           {/* Y axis labels */}
           {[0, 0.25, 0.5, 0.75, 1].map((t, i) => {
-            const y = height - padding - plotHeight * t;
+            const y = SVG_HEIGHT - SVG_PADDING - PLOT_HEIGHT * t;
             const val = yMin + yRange * t;
             return (
               <g key={`y-${i}`}>
                 <line
-                  x1={padding - 5}
+                  x1={SVG_PADDING - 5}
                   y1={y}
-                  x2={padding}
+                  x2={SVG_PADDING}
                   y2={y}
                   stroke="#333"
                   strokeWidth="1"
                 />
                 <text
-                  x={padding - 10}
+                  x={SVG_PADDING - 10}
                   y={y + 4}
                   fontSize="12"
                   textAnchor="end"
@@ -248,9 +425,9 @@ export function Graph({
           {/* Current position indicator */}
           <line
             x1={currentX}
-            y1={padding}
+            y1={SVG_PADDING}
             x2={currentX}
-            y2={height - padding}
+            y2={SVG_HEIGHT - SVG_PADDING}
             stroke="#ef4444"
             strokeWidth="2"
             strokeDasharray="5,5"
@@ -259,8 +436,8 @@ export function Graph({
 
           {/* X axis label */}
           <text
-            x={width / 2}
-            y={height - 5}
+            x={SVG_WIDTH / 2}
+            y={SVG_HEIGHT - 5}
             fontSize="14"
             fontWeight="bold"
             textAnchor="middle"
@@ -297,6 +474,8 @@ export function GraphPanel({
     { value: GraphType.WheelRate, label: "Wheel Rate" },
     { value: GraphType.Trail, label: "Trail" },
     { value: GraphType.PitchAngle, label: "Pitch Angle" },
+    { value: GraphType.RearCenter, label: "Rear Center" },
+    { value: GraphType.AxlePath, label: "Wheel Path" },
   ];
 
   return (

--- a/components/Visualization.tsx
+++ b/components/Visualization.tsx
@@ -166,7 +166,7 @@ export function AnimationView({
   onCoupledChange,
   ...props
 }: AnimationViewProps) {
-  const axlePath = props.analysisResults.states.map((s) => s.rearAxle.world);
+  const axlePath = props.analysisResults.axlePath;
   // Shock position is kept local — it drives animation independently of fork
   const [shockPercent, setShockPercent] = React.useState(initialTravelPercentage);
 

--- a/components/Visualization.tsx
+++ b/components/Visualization.tsx
@@ -164,11 +164,13 @@ export function AnimationView({
   coupled,
   onForkCompressionChange,
   onCoupledChange,
+  showCalculations: initialShowCalculations = true,
   ...props
 }: AnimationViewProps) {
   const axlePath = props.analysisResults.axlePath;
   // Shock position is kept local — it drives animation independently of fork
   const [shockPercent, setShockPercent] = React.useState(initialTravelPercentage);
+  const [showWorkingLines, setShowWorkingLines] = React.useState(initialShowCalculations);
 
   React.useEffect(() => {
     if (!isAnimating) return;
@@ -205,21 +207,33 @@ export function AnimationView({
         forkCompressionPercent={effectiveForkPercent}
         {...props}
         axlePath={axlePath}
+        showCalculations={showWorkingLines}
       />
       <div className="p-4 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800 space-y-2">
         <div className="flex items-center justify-between">
           <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
             Compression
           </span>
-          <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              checked={coupled}
-              onChange={(e) => handleCoupledChange(e.target.checked)}
-              className="w-4 h-4"
-            />
-            Couple fork &amp; shock
-          </label>
+          <div className="flex items-center gap-4">
+            <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={showWorkingLines}
+                onChange={(e) => setShowWorkingLines(e.target.checked)}
+                className="w-4 h-4"
+              />
+              Working lines
+            </label>
+            <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={coupled}
+                onChange={(e) => handleCoupledChange(e.target.checked)}
+                className="w-4 h-4"
+              />
+              Couple fork &amp; shock
+            </label>
+          </div>
         </div>
 
         {/* Shock slider */}

--- a/components/visualization/Calculations.tsx
+++ b/components/visualization/Calculations.tsx
@@ -5,7 +5,7 @@ import {
   Point2D,
 } from "@/lib/types";
 import { DrawComponentProps } from "./types";
-import { doAntiSquatCalculations } from "@/lib/kinematics";
+import { doAntiSquatCalculations, doAntiRiseCalculations } from "@/lib/kinematics";
 
 /**
  *
@@ -212,10 +212,7 @@ const AntiSquatCalculations = ({
   state,
   geometry,
 }: DrawComponentProps) => {
-  const calculations = doAntiSquatCalculations(state, geometry, {
-    warn: true,
-  });
-  console.log("Drawing anti squat", calculations);
+  const calculations = doAntiSquatCalculations(state, geometry);
   return (
     <>
       <ReferenceLine line={calculations.chainForce} conversion={conversion} />
@@ -251,14 +248,44 @@ const AntiSquatCalculations = ({
   );
 };
 
+const AntiRiseCalculations = ({
+  conversion,
+  state,
+  geometry,
+}: DrawComponentProps) => {
+  const calculations = doAntiRiseCalculations(state, geometry);
+  return (
+    <>
+      <ReferenceLine line={calculations.forceLine} conversion={conversion} />
+      {"antiRiseIntersection" in calculations && (
+        <>
+          <ReferenceVerticalLine
+            x={calculations.frontContactPatch.x}
+            conversion={conversion}
+          />
+          <ReferencePoint
+            point={calculations.antiRiseIntersection}
+            conversion={conversion}
+          />
+          <ReferenceHorizontalLine
+            y={calculations.centreOfMassHeight}
+            conversion={conversion}
+          />
+        </>
+      )}
+    </>
+  );
+};
+
 export const Calculations = ({
   selectedGraph,
   ...props
 }: DrawComponentProps & { selectedGraph: string }) => {
-  console.log("Drawing calculations for " + selectedGraph);
   switch (selectedGraph) {
     case GraphType.AntiSquat:
       return <AntiSquatCalculations {...props} />;
+    case GraphType.AntiRise:
+      return <AntiRiseCalculations {...props} />;
     default:
       return null;
   }

--- a/lib/kinematics.ts
+++ b/lib/kinematics.ts
@@ -810,6 +810,54 @@ export const doAntiSquatCalculations = (
   );
 };
 
+// ---- Anti-rise types (exported for Calculations.tsx) ----
+type AntiRiseStep1 = {
+  forceLine: LineSegment; // rear axle → instant center (pivot)
+};
+type AntiRiseFinal = AntiRiseStep1 & {
+  antiRiseIntersection: Point2D;
+  frontContactPatch: Point2D;
+  centreOfMassHeight: number;
+};
+export type AntiRiseCalculations = AntiRiseStep1 | AntiRiseFinal;
+
+// Exported: used by Calculations.tsx to display anti-rise force lines
+export const doAntiRiseCalculations = (
+  state: KinematicState,
+  geometry: BikeGeometry,
+): AntiRiseCalculations => {
+  const applyPitchRotation = getApplyPitchRotation(
+    state.rearAxle.world,
+    state.pitchAngleDegrees,
+  );
+
+  const instantCenter = applyPitchRotation(state.pivot.world);
+  const rearAxleRotated = applyPitchRotation(state.rearAxle.world);
+  const frontAxleRotated = applyPitchRotation(state.frontAxle.world);
+
+  const step1: AntiRiseStep1 = {
+    forceLine: { start: rearAxleRotated, end: instantCenter },
+  };
+
+  const antiRiseIntersection = lineIntersectionWithVertical(
+    rearAxleRotated,
+    instantCenter,
+    frontAxleRotated.x,
+  );
+  if (!antiRiseIntersection) return step1;
+
+  const centreOfMassHeight = applyPitchRotation(
+    Point2D.add(state.bb.world, { x: geometry.comX, y: geometry.comY }),
+  ).y;
+
+  return {
+    ...step1,
+    antiRiseIntersection,
+    frontContactPatch: { x: frontAxleRotated.x, y: 0 },
+    centreOfMassHeight,
+  } satisfies AntiRiseFinal;
+};
+
 function calculateVisualAntiSquat(
   fp: FirstPassState,
   frontAxlePos: Point2D,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -200,6 +200,7 @@ export enum GraphType {
   AntiRise = "Anti-Rise",
   PedalKickback = "Pedal Kickback",
   AxlePath = "Wheel Path",
+  RearCenter = "Rear Center",
   ChainGrowth = "Chain Growth",
   WheelRate = "Wheel Rate",
   Trail = "Trail",


### PR DESCRIPTION
- Fix: axle path on the main bike visualization was showing as a short
  horizontal line because AnimationView was passing world-space rear axle
  coordinates (y always = rearWheelRadius, nearly constant) instead of
  the pre-computed frame-relative path from AnalysisResults.axlePath.
  Now passes axlePath directly so AxlePath.tsx receives the correct
  BB-relative offsets it was designed for.

- Add GraphType.RearCenter: standard Y-vs-travel graph showing the
  horizontal distance from BB to rear axle across the shock stroke.

- Add GraphType.AxlePath (Wheel Path): 2-D scatter plot of rear axle
  position relative to BB (rearward X vs upward Y), with a red dot
  tracking the current travel position.  Axes are labelled
  "Rearward from BB" / "Upward from BB".

- Refactor Graph component: extract shared SVG constants (SVG_WIDTH,
  SVG_HEIGHT, SVG_PADDING, PLOT_WIDTH, PLOT_HEIGHT) and a GridAndAxes
  sub-component to avoid duplication between the standard and 2-D plots.

https://claude.ai/code/session_0196J5xY8s3WU6UpfTJhec8g