### PR TITLE
Add four-bar linkage suspension type and dedicated linkage inspector

### DIFF
--- a/app/linkage/page.tsx
+++ b/app/linkage/page.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import React, { useState, useEffect, useRef } from "react";
+import Link from "next/link";
+import { useBikeViewModel } from "@/hooks/useBikeViewModel";
+import {
+  InputSection,
+  InputField,
+  FourBarLinkageInputs,
+} from "@/components/InputPanel";
+import { LinkageVisualization } from "@/components/LinkageVisualization";
+import { GraphPanel } from "@/components/Graphs";
+import { SuspensionType } from "@/lib/types";
+
+export default function LinkagePage() {
+  const viewModel = useBikeViewModel({
+    geometryOverrides: { suspensionType: SuspensionType.FourBar },
+  });
+
+  const [shockPercent, setShockPercent] = useState(0);
+  const [isAnimating, setIsAnimating] = useState(false);
+  const shockPercentRef = useRef(shockPercent);
+
+  useEffect(() => {
+    shockPercentRef.current = shockPercent;
+  }, [shockPercent]);
+
+  useEffect(() => {
+    if (!isAnimating) return;
+    const interval = setInterval(() => {
+      const next = shockPercentRef.current + 0.5;
+      setShockPercent(next > 100 ? 0 : next);
+    }, 50);
+    return () => clearInterval(interval);
+  }, [isAnimating]);
+
+  return (
+    <div className="flex flex-col min-h-screen lg:h-screen w-screen bg-gray-50 dark:bg-gray-950 lg:overflow-hidden">
+      {/* Header */}
+      <header className="sticky top-0 z-20 bg-white/90 dark:bg-gray-900/90 backdrop-blur border-b border-gray-200 dark:border-gray-800 px-3 py-2.5 lg:px-6 lg:py-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h1 className="text-base lg:text-lg font-bold tracking-tight text-gray-900 dark:text-white truncate leading-tight">
+              Four-Bar Linkage Inspector
+            </h1>
+            <p className="hidden sm:block text-[11px] text-gray-500 dark:text-gray-400 leading-tight truncate">
+              Isolate and study the rear linkage kinematics
+            </p>
+          </div>
+          <div className="flex items-center gap-1.5 lg:gap-2 flex-shrink-0">
+            <Link
+              href="/"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            >
+              ← Full bike
+            </Link>
+            <button
+              onClick={() => setIsAnimating(!isAnimating)}
+              className={`inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors ${
+                isAnimating
+                  ? "bg-red-500 hover:bg-red-600"
+                  : "bg-blue-600 hover:bg-blue-700"
+              }`}
+            >
+              {isAnimating ? "Stop" : "Animate"}
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div className="flex flex-1 lg:overflow-hidden flex-col lg:flex-row">
+        {/* Sidebar: linkage inputs */}
+        <div className="w-full lg:w-80 xl:w-96 lg:border-r lg:border-gray-200 lg:dark:border-gray-800 lg:overflow-y-auto bg-gray-50 dark:bg-gray-950">
+          <div className="p-4 space-y-3">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+              Linkage Geometry
+            </h2>
+            <InputSection title="Four-Bar Linkage">
+              <FourBarLinkageInputs
+                geometry={viewModel.geometry}
+                onGeometryChange={viewModel.updateGeometry}
+              />
+            </InputSection>
+            <InputSection title="Shock" defaultOpen={false}>
+              <InputField
+                label="Stroke"
+                unit="mm"
+                value={viewModel.geometry.shockStroke}
+                onChange={(val) =>
+                  viewModel.updateGeometry({ shockStroke: val as number })
+                }
+              />
+              <InputField
+                label="Spring Rate"
+                unit="N/mm"
+                value={viewModel.geometry.shockSpringRate}
+                onChange={(val) =>
+                  viewModel.updateGeometry({ shockSpringRate: val as number })
+                }
+              />
+              <InputField
+                label="Frame Mount X"
+                unit="mm"
+                value={viewModel.geometry.shockFrameMountX}
+                onChange={(val) =>
+                  viewModel.updateGeometry({ shockFrameMountX: val as number })
+                }
+              />
+              <InputField
+                label="Frame Mount Y"
+                unit="mm"
+                value={viewModel.geometry.shockFrameMountY}
+                onChange={(val) =>
+                  viewModel.updateGeometry({ shockFrameMountY: val as number })
+                }
+              />
+            </InputSection>
+          </div>
+        </div>
+
+        {/* Right panel: visualization + graphs */}
+        <div className="flex-1 min-w-0 flex flex-col lg:overflow-hidden">
+          <div className="lg:flex-[3] lg:min-h-0 flex flex-col h-[60vh] lg:h-auto">
+            <div className="flex-1 min-h-0">
+              <LinkageVisualization
+                geometry={viewModel.geometry}
+                analysisResults={viewModel.analysisResults}
+                travelPercentage={shockPercent}
+              />
+            </div>
+            <div className="px-4 py-3 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800">
+              <div className="flex items-center gap-3">
+                <span className="w-16 flex-shrink-0 text-right text-xs font-medium text-gray-500 dark:text-gray-400">
+                  Shock
+                </span>
+                <input
+                  type="range"
+                  min="0"
+                  max="100"
+                  step="0.5"
+                  value={shockPercent}
+                  onChange={(e) => setShockPercent(parseFloat(e.target.value))}
+                  style={{ "--p": `${shockPercent}%` } as React.CSSProperties}
+                  className="slider flex-1 cursor-pointer"
+                />
+                <span className="w-14 flex-shrink-0 text-right font-mono text-xs text-gray-600 dark:text-gray-300 tabular-nums">
+                  {shockPercent.toFixed(1)}%
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="lg:flex-[2] lg:min-h-0 lg:overflow-hidden lg:border-t lg:border-gray-200 lg:dark:border-gray-800 flex flex-col h-[40vh] lg:h-auto">
+            <GraphPanel
+              results={viewModel.analysisResults}
+              selectedGraph={viewModel.selectedGraph}
+              onGraphChange={viewModel.setSelectedGraph}
+              travelPercentage={shockPercent}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import Link from "next/link";
 import { useBikeViewModel } from "@/hooks/useBikeViewModel";
 import { InputPanel } from "@/components/InputPanel";
 import { AnimationView } from "@/components/Visualization";
@@ -143,6 +144,14 @@ export default function Home() {
             </div>
           </div>
           <div className="flex items-center gap-1.5 lg:gap-2 flex-shrink-0">
+            <Link
+              href="/linkage"
+              className={secondaryButtonClass}
+              title="Open the four-bar linkage inspector"
+            >
+              <ChartIcon className="w-4 h-4" />
+              <span className="hidden md:inline">Linkage</span>
+            </Link>
             <label className={secondaryButtonClass} title="Open design (.json)">
               <OpenIcon />
               <span className="hidden md:inline">Open</span>

--- a/components/InputPanel.tsx
+++ b/components/InputPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { BikeGeometry, IdlerType } from "@/lib/types";
+import { BikeGeometry, IdlerType, SuspensionType } from "@/lib/types";
 import { Attribution } from "./Attribution";
 
 interface InputFieldProps {
@@ -134,6 +134,133 @@ export function InputSection({
   );
 }
 
+interface GeometryInputsProps {
+  geometry: BikeGeometry;
+  onGeometryChange: (updates: Partial<BikeGeometry>) => void;
+}
+
+export function SuspensionTypeField({
+  geometry,
+  onGeometryChange,
+}: GeometryInputsProps) {
+  return (
+    <InputField
+      label="Suspension Type"
+      value={geometry.suspensionType}
+      onChange={(val) =>
+        onGeometryChange({ suspensionType: val as SuspensionType })
+      }
+      type="select"
+      options={[
+        { value: SuspensionType.SinglePivot, label: "Single Pivot" },
+        { value: SuspensionType.FourBar, label: "Four Bar" },
+      ]}
+    />
+  );
+}
+
+// Top-out positions of the four-bar joints (mm from BB). Reused by the main
+// input panel and the dedicated linkage page.
+export function FourBarLinkageInputs({
+  geometry,
+  onGeometryChange,
+}: GeometryInputsProps) {
+  return (
+    <>
+      <InputGroupLabel>Main Pivot (chainstay, from BB)</InputGroupLabel>
+      <InputField
+        label="X"
+        unit="mm"
+        value={geometry.lowerLinkPivotX}
+        onChange={(val) => onGeometryChange({ lowerLinkPivotX: val as number })}
+        className="pl-2"
+      />
+      <InputField
+        label="Y"
+        unit="mm"
+        value={geometry.lowerLinkPivotY}
+        onChange={(val) => onGeometryChange({ lowerLinkPivotY: val as number })}
+        className="pl-2"
+      />
+      <InputGroupLabel>Rocker Pivot (from BB)</InputGroupLabel>
+      <InputField
+        label="X"
+        unit="mm"
+        value={geometry.rockerPivotX}
+        onChange={(val) => onGeometryChange({ rockerPivotX: val as number })}
+        className="pl-2"
+      />
+      <InputField
+        label="Y"
+        unit="mm"
+        value={geometry.rockerPivotY}
+        onChange={(val) => onGeometryChange({ rockerPivotY: val as number })}
+        className="pl-2"
+      />
+      <InputGroupLabel>Rocker → Shock Eye (from BB)</InputGroupLabel>
+      <InputField
+        label="X"
+        unit="mm"
+        value={geometry.rockerShockMountX}
+        onChange={(val) => onGeometryChange({ rockerShockMountX: val as number })}
+        className="pl-2"
+      />
+      <InputField
+        label="Y"
+        unit="mm"
+        value={geometry.rockerShockMountY}
+        onChange={(val) => onGeometryChange({ rockerShockMountY: val as number })}
+        className="pl-2"
+      />
+      <InputGroupLabel>Rocker → Seatstay Joint (from BB)</InputGroupLabel>
+      <InputField
+        label="X"
+        unit="mm"
+        value={geometry.rockerSeatstayX}
+        onChange={(val) => onGeometryChange({ rockerSeatstayX: val as number })}
+        className="pl-2"
+      />
+      <InputField
+        label="Y"
+        unit="mm"
+        value={geometry.rockerSeatstayY}
+        onChange={(val) => onGeometryChange({ rockerSeatstayY: val as number })}
+        className="pl-2"
+      />
+      <InputGroupLabel>Chainstay → Seatstay Joint (from BB)</InputGroupLabel>
+      <InputField
+        label="X"
+        unit="mm"
+        value={geometry.seatstayLowerX}
+        onChange={(val) => onGeometryChange({ seatstayLowerX: val as number })}
+        className="pl-2"
+      />
+      <InputField
+        label="Y"
+        unit="mm"
+        value={geometry.seatstayLowerY}
+        onChange={(val) => onGeometryChange({ seatstayLowerY: val as number })}
+        className="pl-2"
+      />
+      <InputGroupLabel>Rear Axle (from BB)</InputGroupLabel>
+      <InputField
+        label="X"
+        unit="mm"
+        value={geometry.fourBarAxleX}
+        onChange={(val) => onGeometryChange({ fourBarAxleX: val as number })}
+        className="pl-2"
+      />
+      <InputField
+        label="Y"
+        unit="mm"
+        value={geometry.fourBarAxleY}
+        onChange={(val) => onGeometryChange({ fourBarAxleY: val as number })}
+        className="pl-2"
+      />
+    </>
+  );
+}
+
 interface InputPanelProps {
   geometry: BikeGeometry;
   onGeometryChange: (updates: Partial<BikeGeometry>) => void;
@@ -176,6 +303,14 @@ export function InputPanel({
             className="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500/60 focus:border-blue-500 transition-shadow"
           />
         </div>
+
+        {/* Suspension type */}
+        <InputSection title="Suspension Layout">
+          <SuspensionTypeField
+            geometry={geometry}
+            onGeometryChange={onGeometryChange}
+          />
+        </InputSection>
 
         {/* Frame */}
         <InputSection title="Frame">
@@ -261,26 +396,34 @@ export function InputPanel({
 
         {/* Suspension */}
         <InputSection title="Suspension">
-          <InputField
-            label="Swingarm Length"
-            unit="mm"
-            value={geometry.swingarmLength}
-            onChange={(val) =>
-              onGeometryChange({ swingarmLength: val as number })
-            }
-          />
-          <InputField
-            label="Pivot X"
-            unit="mm"
-            value={geometry.bbToPivotX}
-            onChange={(val) => onGeometryChange({ bbToPivotX: val as number })}
-          />
-          <InputField
-            label="Pivot Y"
-            unit="mm"
-            value={geometry.bbToPivotY}
-            onChange={(val) => onGeometryChange({ bbToPivotY: val as number })}
-          />
+          {geometry.suspensionType === SuspensionType.SinglePivot && (
+            <>
+              <InputField
+                label="Swingarm Length"
+                unit="mm"
+                value={geometry.swingarmLength}
+                onChange={(val) =>
+                  onGeometryChange({ swingarmLength: val as number })
+                }
+              />
+              <InputField
+                label="Pivot X"
+                unit="mm"
+                value={geometry.bbToPivotX}
+                onChange={(val) =>
+                  onGeometryChange({ bbToPivotX: val as number })
+                }
+              />
+              <InputField
+                label="Pivot Y"
+                unit="mm"
+                value={geometry.bbToPivotY}
+                onChange={(val) =>
+                  onGeometryChange({ bbToPivotY: val as number })
+                }
+              />
+            </>
+          )}
           <InputField
             label="Rear Wheel Diameter"
             unit="mm"
@@ -290,6 +433,16 @@ export function InputPanel({
             }
           />
         </InputSection>
+
+        {/* Four-bar linkage */}
+        {geometry.suspensionType === SuspensionType.FourBar && (
+          <InputSection title="Four-Bar Linkage">
+            <FourBarLinkageInputs
+              geometry={geometry}
+              onGeometryChange={onGeometryChange}
+            />
+          </InputSection>
+        )}
 
         {/* Shock */}
         <InputSection title="Shock">
@@ -332,16 +485,20 @@ export function InputPanel({
             }
             className="pl-2"
           />
-          <InputGroupLabel>Swingarm Mount</InputGroupLabel>
-          <InputField
-            label="Distance from pivot"
-            unit="mm"
-            value={geometry.shockSwingarmMountDistance}
-            onChange={(val) =>
-              onGeometryChange({ shockSwingarmMountDistance: val as number })
-            }
-            className="pl-2"
-          />
+          {geometry.suspensionType === SuspensionType.SinglePivot && (
+            <>
+              <InputGroupLabel>Swingarm Mount</InputGroupLabel>
+              <InputField
+                label="Distance from pivot"
+                unit="mm"
+                value={geometry.shockSwingarmMountDistance}
+                onChange={(val) =>
+                  onGeometryChange({ shockSwingarmMountDistance: val as number })
+                }
+                className="pl-2"
+              />
+            </>
+          )}
         </InputSection>
 
         {/* Drivetrain */}

--- a/components/LinkageVisualization.tsx
+++ b/components/LinkageVisualization.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import {
+  BikeGeometry,
+  AnalysisResults,
+  VisualizationBounds,
+  getScreenConversions,
+  Point2D,
+} from "@/lib/types";
+import { Linkage } from "./visualization/Linkage";
+import { Shock } from "./visualization/Shock";
+import { AxlePath } from "./visualization/AxlePath";
+
+type Props = {
+  geometry: BikeGeometry;
+  analysisResults: AnalysisResults;
+  travelPercentage: number; // 0-100
+};
+
+// Collects the linkage-relevant points of a state in the displayed (pitched) frame.
+function statePoints(state: AnalysisResults["states"][number]): Point2D[] {
+  const pts: Point2D[] = [
+    state.rearAxle.wheelsOnGround,
+    state.swingarmEye.wheelsOnGround,
+    state.shockFrameMount.wheelsOnGround,
+    state.pivot.wheelsOnGround,
+  ];
+  if (state.fourBar) {
+    pts.push(
+      state.fourBar.mainPivot.wheelsOnGround,
+      state.fourBar.rockerPivot.wheelsOnGround,
+      state.fourBar.seatstayLower.wheelsOnGround,
+      state.fourBar.seatstayUpper.wheelsOnGround,
+    );
+  }
+  return pts;
+}
+
+export function LinkageVisualization({
+  geometry,
+  analysisResults,
+  travelPercentage,
+}: Props) {
+  if (analysisResults.states.length === 0) {
+    return (
+      <div className="w-full h-full flex items-center justify-center bg-gray-100 dark:bg-gray-900">
+        <p className="text-gray-500 dark:text-gray-400">Loading...</p>
+      </div>
+    );
+  }
+
+  const stateIndex = Math.max(
+    0,
+    Math.min(
+      Math.floor((travelPercentage / 100) * (analysisResults.states.length - 1)),
+      analysisResults.states.length - 1,
+    ),
+  );
+  const state = analysisResults.states[stateIndex];
+
+  // Stable bounds across the whole sweep so the view doesn't jump while scrubbing.
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const s of analysisResults.states) {
+    for (const p of statePoints(s)) {
+      minX = Math.min(minX, p.x);
+      maxX = Math.max(maxX, p.x);
+      minY = Math.min(minY, p.y);
+      maxY = Math.max(maxY, p.y);
+    }
+  }
+
+  const padding = 50;
+  const scale = 0.5; // larger than the full-bike view: we are zoomed on the linkage
+  const bounds: VisualizationBounds = {
+    minX,
+    maxX,
+    minY,
+    maxY,
+    padding,
+    scale,
+  };
+
+  const conversion = getScreenConversions(bounds);
+  const { width, height, toCanvasX, toCanvasY } = conversion;
+  const drawProps = { geometry, state, conversion };
+
+  const ic = state.pivot.wheelsOnGround;
+
+  return (
+    <div className="w-full h-full flex items-center justify-center bg-gray-50 dark:bg-gray-950 overflow-hidden p-3 lg:p-4">
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="xMidYMid meet"
+        className="w-full h-full rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-sm"
+      >
+        <defs>
+          <pattern
+            id="linkage-grid"
+            width={50 * scale}
+            height={50 * scale}
+            patternUnits="userSpaceOnUse"
+          >
+            <path
+              d={`M ${50 * scale} 0 L 0 0 0 ${50 * scale}`}
+              fill="none"
+              stroke="#9ca3af"
+              strokeWidth="0.5"
+              opacity="0.3"
+            />
+          </pattern>
+        </defs>
+        <rect width={width} height={height} fill="url(#linkage-grid)" />
+
+        {/* Rear axle path trace */}
+        <AxlePath axlePath={analysisResults.axlePath} {...drawProps} />
+
+        <Linkage {...drawProps} />
+        <Shock {...drawProps} />
+
+        {/* Rear axle marker */}
+        <circle
+          cx={toCanvasX(state.rearAxle.wheelsOnGround.x)}
+          cy={toCanvasY(state.rearAxle.wheelsOnGround.y)}
+          r={5}
+          fill="none"
+          stroke="#2563eb"
+          strokeWidth="1.5"
+        />
+
+        {/* Instant centre marker */}
+        <circle
+          cx={toCanvasX(ic.x)}
+          cy={toCanvasY(ic.y)}
+          r={4}
+          fill="#16a34a"
+        />
+        <text
+          x={toCanvasX(ic.x) + 8}
+          y={toCanvasY(ic.y) - 6}
+          fontSize="11"
+          fill="#16a34a"
+        >
+          Instant centre
+        </text>
+
+        {/* Metric readout */}
+        <text
+          x={padding}
+          y={26}
+          fontSize="13"
+          fontWeight="bold"
+          fill="#1f2937"
+          className="dark:fill-white"
+        >
+          Travel: {state.travelMM.toFixed(1)} mm | LR:{" "}
+          {state.leverageRatio.toFixed(2)} | AS: {state.antiSquat.toFixed(0)}%
+        </text>
+      </svg>
+    </div>
+  );
+}

--- a/components/Visualization.tsx
+++ b/components/Visualization.tsx
@@ -8,10 +8,12 @@ import {
   getScreenConversions,
   Point2D,
 } from "@/lib/types";
+import { SuspensionType } from "@/lib/types";
 import { overrideForkCompression } from "@/lib/kinematics";
 import { GroundLine } from "./visualization/GroundLine";
 import { FrontTriangle } from "./visualization/FrontTriangle";
 import { Swingarm } from "./visualization/Swingarm";
+import { Linkage } from "./visualization/Linkage";
 import { Fork } from "./visualization/Fork";
 import { Wheels } from "./visualization/Wheels";
 import { Drivetrain } from "./visualization/Drivetrain";
@@ -128,7 +130,11 @@ export function BikeVisualization({
 
         <GroundLine {...drawProps} />
         <FrontTriangle {...drawProps} />
-        <Swingarm {...drawProps} />
+        {geometry.suspensionType === SuspensionType.FourBar ? (
+          <Linkage {...drawProps} />
+        ) : (
+          <Swingarm {...drawProps} />
+        )}
         <Fork {...drawProps} />
         <Wheels {...drawProps} />
         <Drivetrain {...drawProps} />

--- a/components/visualization/Calculations.tsx
+++ b/components/visualization/Calculations.tsx
@@ -3,6 +3,7 @@ import {
   GraphType,
   LineSegment,
   Point2D,
+  SuspensionType,
 } from "@/lib/types";
 import { DrawComponentProps } from "./types";
 import { doAntiSquatCalculations, doAntiRiseCalculations } from "@/lib/kinematics";
@@ -277,10 +278,39 @@ const AntiRiseCalculations = ({
   );
 };
 
-export const Calculations = ({
-  selectedGraph,
-  ...props
-}: DrawComponentProps & { selectedGraph: string }) => {
+// For a four-bar linkage the rear-wheel pivot is virtual: it is the instant
+// centre where the chainstay line and the rocker→seatstay line meet. Draw both
+// lines (extended) and mark their intersection so it is visible for every graph.
+const InstantCentreCalculations = ({ conversion, state }: DrawComponentProps) => {
+  const fourBar = state.fourBar;
+  if (!fourBar) return null;
+
+  const chainstayLine: LineSegment = {
+    start: fourBar.mainPivot.wheelsOnGround,
+    end: fourBar.seatstayLower.wheelsOnGround,
+  };
+  const rockerLine: LineSegment = {
+    start: fourBar.rockerPivot.wheelsOnGround,
+    end: fourBar.seatstayUpper.wheelsOnGround,
+  };
+  const ic = conversion.toCanvas(state.pivot.wheelsOnGround);
+
+  return (
+    <>
+      <ReferenceLine line={chainstayLine} conversion={conversion} />
+      <ReferenceLine line={rockerLine} conversion={conversion} />
+      <circle cx={ic.x} cy={ic.y} r={4} fill="#16a34a" />
+      <text x={ic.x + 8} y={ic.y - 6} fontSize="11" fill="#16a34a">
+        Instant centre
+      </text>
+    </>
+  );
+};
+
+const graphCalculations = (
+  selectedGraph: string,
+  props: DrawComponentProps,
+) => {
   switch (selectedGraph) {
     case GraphType.AntiSquat:
       return <AntiSquatCalculations {...props} />;
@@ -289,6 +319,20 @@ export const Calculations = ({
     default:
       return null;
   }
+};
+
+export const Calculations = ({
+  selectedGraph,
+  ...props
+}: DrawComponentProps & { selectedGraph: string }) => {
+  const isFourBar =
+    props.geometry.suspensionType === SuspensionType.FourBar;
+  return (
+    <>
+      {isFourBar && <InstantCentreCalculations {...props} />}
+      {graphCalculations(selectedGraph, props)}
+    </>
+  );
 };
 
 export default Calculations;

--- a/components/visualization/Linkage.tsx
+++ b/components/visualization/Linkage.tsx
@@ -1,0 +1,84 @@
+import { DrawComponentProps } from "./types";
+import { pointsToPolylineString } from "./lib";
+
+// Renders a four-bar linkage: chainstay (lower link), seatstay (coupler that
+// carries the rear axle) and rocker (upper link driven by the shock).
+// Falls back to nothing if the state has no four-bar data.
+export const Linkage = ({ state, conversion }: DrawComponentProps) => {
+  const fourBar = state.fourBar;
+  if (!fourBar) return null;
+
+  const { toCanvas, toCanvasX, toCanvasY } = conversion;
+
+  const mainPivot = fourBar.mainPivot.wheelsOnGround;
+  const rockerPivot = fourBar.rockerPivot.wheelsOnGround;
+  const seatstayLower = fourBar.seatstayLower.wheelsOnGround;
+  const seatstayUpper = fourBar.seatstayUpper.wheelsOnGround;
+  const shockEye = state.swingarmEye.wheelsOnGround;
+  const rearAxle = state.rearAxle.wheelsOnGround;
+
+  // Chainstay: main pivot → lower seatstay junction → rear axle
+  const chainstay = [mainPivot, seatstayLower, rearAxle].map(toCanvas);
+  // Seatstay coupler: lower junction → upper junction (+ axle triangle)
+  const seatstay = [seatstayLower, seatstayUpper, rearAxle].map(toCanvas);
+  // Rocker: rocker pivot → upper seatstay junction, plus rocker pivot → shock eye
+  const rocker = [seatstayUpper, rockerPivot, shockEye].map(toCanvas);
+
+  return (
+    <>
+      {/* Chainstay (lower link) */}
+      <polyline
+        points={pointsToPolylineString(chainstay)}
+        fill="none"
+        stroke="#f97316"
+        strokeWidth="1.6"
+      />
+      {/* Seatstay (coupler carrying the axle) */}
+      <polyline
+        points={pointsToPolylineString(seatstay)}
+        fill="none"
+        stroke="#f59e0b"
+        strokeWidth="1.6"
+      />
+      {/* Rocker (upper link) */}
+      <polyline
+        points={pointsToPolylineString(rocker)}
+        fill="none"
+        stroke="#d97706"
+        strokeWidth="1.6"
+      />
+
+      {/* Frame pivots — hollow yellow circles */}
+      <circle
+        cx={toCanvasX(mainPivot.x)}
+        cy={toCanvasY(mainPivot.y)}
+        r={6}
+        fill="none"
+        stroke="#eab308"
+        strokeWidth="1.33"
+      />
+      <circle
+        cx={toCanvasX(rockerPivot.x)}
+        cy={toCanvasY(rockerPivot.y)}
+        r={6}
+        fill="none"
+        stroke="#eab308"
+        strokeWidth="1.33"
+      />
+
+      {/* Coupler joints — small solid orange dots */}
+      <circle
+        cx={toCanvasX(seatstayLower.x)}
+        cy={toCanvasY(seatstayLower.y)}
+        r={3.5}
+        fill="#f97316"
+      />
+      <circle
+        cx={toCanvasX(seatstayUpper.x)}
+        cy={toCanvasY(seatstayUpper.y)}
+        r={3.5}
+        fill="#f97316"
+      />
+    </>
+  );
+};

--- a/hooks/useBikeViewModel.ts
+++ b/hooks/useBikeViewModel.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import {
   BikeGeometry,
   AnalysisResults,
@@ -30,10 +30,18 @@ const getOverridesFromQuery = (idlerQuery: string | null) => {
 
 type Options = {
   idlerQuery?: string | null;
+  /** Extra geometry overrides applied on top of defaults (e.g. forcing a suspension type). */
+  geometryOverrides?: Partial<BikeGeometry>;
 };
 
-export function useBikeViewModel({ idlerQuery = null }: Options = {}) {
-  const overrides = getOverridesFromQuery(idlerQuery);
+export function useBikeViewModel({
+  idlerQuery = null,
+  geometryOverrides,
+}: Options = {}) {
+  const overrides = useMemo(
+    () => ({ ...getOverridesFromQuery(idlerQuery), ...geometryOverrides }),
+    [idlerQuery, geometryOverrides],
+  );
   const [geometry, setGeometry] = useState<BikeGeometry>(
     createDefaultGeometry({ overrides }),
   );

--- a/lib/fourbar.test.ts
+++ b/lib/fourbar.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { runKinematicAnalysis } from "./kinematics";
-import { createDefaultGeometry, SuspensionType } from "./types";
+import { runKinematicAnalysis, getIdlerPosition } from "./kinematics";
+import { createDefaultGeometry, SuspensionType, IdlerType } from "./types";
 import { distance, lineIntersection } from "./geometry";
 
 const fourBarGeometry = () =>
@@ -139,5 +139,95 @@ describe("Four-bar linkage", () => {
     for (const state of results.states) {
       expect(state.rearAxle.world.y).toBeCloseTo(rearWheelRadius, 3);
     }
+  });
+
+  describe("swingarm-mounted idler", () => {
+    const geometry = createDefaultGeometry({
+      overrides: {
+        suspensionType: SuspensionType.FourBar,
+        idlerType: IdlerType.SwingarmMounted,
+        idlerX: -120,
+        idlerY: 120,
+        idlerTeeth: 16,
+      },
+    });
+    const results = runKinematicAnalysis(geometry);
+
+    it("places an idler on every state", () => {
+      for (const state of results.states) {
+        expect(state.idler).not.toBeNull();
+      }
+    });
+
+    it("at top-out the idler sits at the configured BB-relative position", () => {
+      const top = results.states[0];
+      expect(top.idler!.world.x).toBeCloseTo(top.bb.world.x + geometry.idlerX, 3);
+      expect(top.idler!.world.y).toBeCloseTo(top.bb.world.y + geometry.idlerY, 3);
+    });
+
+    it("the idler stays rigidly attached to the seatstay", () => {
+      const TOLERANCE = 0.05; // mm
+      const ref = results.states[0];
+      const dLower0 = distance(ref.idler!.world, ref.fourBar!.seatstayLower.world);
+      const dUpper0 = distance(ref.idler!.world, ref.fourBar!.seatstayUpper.world);
+      const dAxle0 = distance(ref.idler!.world, ref.rearAxle.world);
+      for (const state of results.states) {
+        expect(
+          Math.abs(distance(state.idler!.world, state.fourBar!.seatstayLower.world) - dLower0),
+        ).toBeLessThan(TOLERANCE);
+        expect(
+          Math.abs(distance(state.idler!.world, state.fourBar!.seatstayUpper.world) - dUpper0),
+        ).toBeLessThan(TOLERANCE);
+        expect(
+          Math.abs(distance(state.idler!.world, state.rearAxle.world) - dAxle0),
+        ).toBeLessThan(TOLERANCE);
+      }
+    });
+
+    it("getIdlerPosition matches the state idler position", () => {
+      for (const state of results.states) {
+        const p = getIdlerPosition(state, geometry);
+        expect(p).not.toBeNull();
+        expect(p!.x).toBeCloseTo(state.idler!.world.x, 6);
+        expect(p!.y).toBeCloseTo(state.idler!.world.y, 6);
+      }
+    });
+
+    it("chain growth and pedal kickback are zero at top-out and finite throughout", () => {
+      expect(results.states[0].chainGrowth).toBeCloseTo(0, 5);
+      expect(results.states[0].pedalKickback).toBeCloseTo(0, 5);
+      for (const state of results.states) {
+        expect(Number.isFinite(state.chainGrowth)).toBe(true);
+        expect(Number.isFinite(state.pedalKickback)).toBe(true);
+        expect(Number.isFinite(state.antiSquat)).toBe(true);
+      }
+    });
+  });
+
+  describe("frame-mounted idler", () => {
+    const geometry = createDefaultGeometry({
+      overrides: {
+        suspensionType: SuspensionType.FourBar,
+        idlerType: IdlerType.FrameMounted,
+        idlerX: -60,
+        idlerY: 160,
+        idlerTeeth: 16,
+      },
+    });
+    const results = runKinematicAnalysis(geometry);
+
+    it("idler stays at a fixed BB-relative offset", () => {
+      for (const state of results.states) {
+        expect(state.idler!.world.x).toBeCloseTo(state.bb.world.x + geometry.idlerX, 3);
+        expect(state.idler!.world.y).toBeCloseTo(state.bb.world.y + geometry.idlerY, 3);
+      }
+    });
+
+    it("chain growth is zero at top-out and finite throughout", () => {
+      expect(results.states[0].chainGrowth).toBeCloseTo(0, 5);
+      for (const state of results.states) {
+        expect(Number.isFinite(state.chainGrowth)).toBe(true);
+      }
+    });
   });
 });

--- a/lib/fourbar.test.ts
+++ b/lib/fourbar.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import { runKinematicAnalysis } from "./kinematics";
+import { createDefaultGeometry, SuspensionType } from "./types";
+import { distance, lineIntersection } from "./geometry";
+
+const fourBarGeometry = () =>
+  createDefaultGeometry({
+    overrides: { suspensionType: SuspensionType.FourBar },
+  });
+
+describe("Four-bar linkage", () => {
+  it("produces linkage points on every state", () => {
+    const results = runKinematicAnalysis(fourBarGeometry());
+    expect(results.states.length).toBeGreaterThan(0);
+    for (const state of results.states) {
+      expect(state.fourBar).not.toBeNull();
+      expect(state.fourBar!.mainPivot).toBeDefined();
+      expect(state.fourBar!.rockerPivot).toBeDefined();
+      expect(state.fourBar!.seatstayLower).toBeDefined();
+      expect(state.fourBar!.seatstayUpper).toBeDefined();
+    }
+  });
+
+  it("single-pivot bikes have no four-bar points", () => {
+    const results = runKinematicAnalysis(createDefaultGeometry());
+    for (const state of results.states) {
+      expect(state.fourBar).toBeNull();
+    }
+  });
+
+  describe("rigid-body constraints", () => {
+    const results = runKinematicAnalysis(fourBarGeometry());
+    const TOLERANCE = 0.1; // mm
+
+    const lengthIsConstant = (fn: (s: (typeof results.states)[number]) => number) => {
+      const ref = fn(results.states[0]);
+      for (const state of results.states) {
+        expect(Math.abs(fn(state) - ref)).toBeLessThan(TOLERANCE);
+      }
+    };
+
+    it("chainstay length (main pivot → lower junction) is constant", () => {
+      lengthIsConstant((s) =>
+        distance(s.fourBar!.mainPivot.world, s.fourBar!.seatstayLower.world),
+      );
+    });
+
+    it("seatstay length (lower → upper junction) is constant", () => {
+      lengthIsConstant((s) =>
+        distance(s.fourBar!.seatstayLower.world, s.fourBar!.seatstayUpper.world),
+      );
+    });
+
+    it("rocker length (rocker pivot → upper junction) is constant", () => {
+      lengthIsConstant((s) =>
+        distance(s.fourBar!.rockerPivot.world, s.fourBar!.seatstayUpper.world),
+      );
+    });
+
+    it("rear axle stays rigidly attached to the seatstay", () => {
+      lengthIsConstant((s) =>
+        distance(s.fourBar!.seatstayLower.world, s.rearAxle.world),
+      );
+      lengthIsConstant((s) =>
+        distance(s.fourBar!.seatstayUpper.world, s.rearAxle.world),
+      );
+    });
+
+    it("the frame-fixed pivots stay a constant distance apart", () => {
+      lengthIsConstant((s) =>
+        distance(s.fourBar!.mainPivot.world, s.fourBar!.rockerPivot.world),
+      );
+    });
+  });
+
+  it("the stored pivot is the instant centre of the two links", () => {
+    const results = runKinematicAnalysis(fourBarGeometry());
+    // Sample a mid-travel state where the links are not parallel.
+    const state = results.states[Math.floor(results.states.length / 2)];
+    const ic = lineIntersection(
+      state.fourBar!.mainPivot.world,
+      state.fourBar!.seatstayLower.world,
+      state.fourBar!.rockerPivot.world,
+      state.fourBar!.seatstayUpper.world,
+    );
+    expect(ic).not.toBeNull();
+    expect(state.pivot.world.x).toBeCloseTo(ic!.x, 3);
+    expect(state.pivot.world.y).toBeCloseTo(ic!.y, 3);
+  });
+
+  it("reaches roughly the configured travel and is monotonic", () => {
+    const results = runKinematicAnalysis(fourBarGeometry());
+    const travels = results.states.map((s) => s.travelMM);
+    const maxTravel = Math.max(...travels);
+    expect(maxTravel).toBeGreaterThan(120);
+    expect(maxTravel).toBeLessThan(180);
+    expect(travels[0]).toBeCloseTo(0, 3);
+    for (let i = 1; i < travels.length; i++) {
+      expect(travels[i]).toBeGreaterThanOrEqual(travels[i - 1] - 1e-6);
+    }
+  });
+
+  it("leverage ratio is positive and physically plausible", () => {
+    const results = runKinematicAnalysis(fourBarGeometry());
+    for (const state of results.states) {
+      expect(state.leverageRatio).toBeGreaterThan(1);
+      expect(state.leverageRatio).toBeLessThan(5);
+    }
+  });
+
+  it("all dynamics metrics are finite throughout travel", () => {
+    const results = runKinematicAnalysis(fourBarGeometry());
+    for (const state of results.states) {
+      for (const v of [
+        state.leverageRatio,
+        state.wheelRate,
+        state.antiSquat,
+        state.antiRise,
+        state.pedalKickback,
+        state.chainGrowth,
+        state.trail,
+        state.pitchAngleDegrees,
+      ]) {
+        expect(Number.isFinite(v)).toBe(true);
+      }
+    }
+  });
+
+  it("chain growth and pedal kickback are zero at top-out", () => {
+    const results = runKinematicAnalysis(fourBarGeometry());
+    expect(results.states[0].chainGrowth).toBeCloseTo(0, 5);
+    expect(results.states[0].pedalKickback).toBeCloseTo(0, 5);
+  });
+
+  it("the rear axle rests on the ground at every state", () => {
+    const geometry = fourBarGeometry();
+    const rearWheelRadius = geometry.rearWheelDiameter / 2;
+    const results = runKinematicAnalysis(geometry);
+    for (const state of results.states) {
+      expect(state.rearAxle.world.y).toBeCloseTo(rearWheelRadius, 3);
+    }
+  });
+});

--- a/lib/fourbar.ts
+++ b/lib/fourbar.ts
@@ -1,0 +1,234 @@
+// Four-bar linkage kinematics solver.
+//
+// The linkage is defined by the top-out (resting) positions of its joints.
+// From those we derive the fixed lengths and rigid-body relationships, then
+// solve the single remaining degree of freedom for each shock stroke value.
+//
+// Bodies (all in the "frame-fixed" coordinate frame where the front triangle
+// is static and the BB sits at (0, bbHeight)):
+//   - Frame:     main pivot P and rocker pivot R are fixed.
+//   - Rocker:    rotates about R, carries the moving shock eye S and the upper
+//                seatstay junction Ju.
+//   - Seatstay:  rigid body carrying the lower junction Jl, upper junction Ju
+//                and the rear axle A.
+//   - Chainstay: rotates about P, carries the lower junction Jl.
+//
+// The shock connects the frame mount F to the rocker eye S and drives the
+// linkage. The rear-wheel instant centre is the intersection of the chainstay
+// line (through P and Jl) and the seatstay-via-rocker line (through R and Ju).
+
+import { BikeGeometry, Point2D, computedProperties } from "./types";
+import {
+  distance,
+  angle,
+  rotate,
+  circleCircleIntersection,
+  lineIntersection,
+  transformPointByReferenceLine,
+} from "./geometry";
+
+export interface FourBarSolution {
+  // World-frame points after dropping the frame so the rear axle rests on the ground.
+  bbPosition: Point2D;
+  rearAxlePosition: Point2D;
+  instantCenter: Point2D; // stored as the effective "pivot" for anti-squat/anti-rise
+  shockEyePosition: Point2D; // moving shock mount on the rocker
+  mainPivot: Point2D;
+  rockerPivot: Point2D;
+  seatstayLower: Point2D;
+  seatstayUpper: Point2D;
+  shockLength: number;
+  travelMM: number;
+}
+
+interface FourBarRig {
+  // Frame-fixed reference points at top-out
+  mainPivot: Point2D; // P
+  rockerPivot: Point2D; // R
+  frameMount: Point2D; // F
+  seatstayLower0: Point2D; // Jl at top-out
+  seatstayUpper0: Point2D; // Ju at top-out
+  shockEye0: Point2D; // S at top-out
+  axle0: Point2D; // A at top-out
+  // Fixed lengths
+  chainstayLength: number; // |P - Jl|
+  seatstayLength: number; // |Jl - Ju|
+  rockerShockArm: number; // |R - S|
+  topOutShockLength: number; // |F - S|
+}
+
+const toWorld = (geometry: BikeGeometry, rx: number, ry: number): Point2D => ({
+  x: rx,
+  y: geometry.bbHeight + ry,
+});
+
+export function establishFourBar(geometry: BikeGeometry): FourBarRig {
+  const mainPivot = toWorld(geometry, geometry.lowerLinkPivotX, geometry.lowerLinkPivotY);
+  const rockerPivot = toWorld(geometry, geometry.rockerPivotX, geometry.rockerPivotY);
+  const frameMount = toWorld(geometry, geometry.shockFrameMountX, geometry.shockFrameMountY);
+  const seatstayLower0 = toWorld(geometry, geometry.seatstayLowerX, geometry.seatstayLowerY);
+  const seatstayUpper0 = toWorld(geometry, geometry.rockerSeatstayX, geometry.rockerSeatstayY);
+  const shockEye0 = toWorld(geometry, geometry.rockerShockMountX, geometry.rockerShockMountY);
+  const axle0 = toWorld(geometry, geometry.fourBarAxleX, geometry.fourBarAxleY);
+
+  return {
+    mainPivot,
+    rockerPivot,
+    frameMount,
+    seatstayLower0,
+    seatstayUpper0,
+    shockEye0,
+    axle0,
+    chainstayLength: distance(mainPivot, seatstayLower0),
+    seatstayLength: distance(seatstayLower0, seatstayUpper0),
+    rockerShockArm: distance(rockerPivot, shockEye0),
+    topOutShockLength: distance(frameMount, shockEye0),
+  };
+}
+
+const nearest = (candidates: Point2D[], reference: Point2D): Point2D | null => {
+  if (candidates.length === 0) return null;
+  let best = candidates[0];
+  let bestDist = distance(best, reference);
+  for (let i = 1; i < candidates.length; i++) {
+    const d = distance(candidates[i], reference);
+    if (d < bestDist) {
+      best = candidates[i];
+      bestDist = d;
+    }
+  }
+  return best;
+};
+
+// Tracks the previous step's solution so the smoothly-continued branch of each
+// circle-circle intersection is chosen.
+export interface FourBarTracker {
+  shockEye: Point2D;
+  seatstayLower: Point2D;
+  seatstayUpper: Point2D;
+  instantCenter: Point2D;
+}
+
+export function initialTracker(rig: FourBarRig): FourBarTracker {
+  return {
+    shockEye: rig.shockEye0,
+    seatstayLower: rig.seatstayLower0,
+    seatstayUpper: rig.seatstayUpper0,
+    instantCenter: rig.mainPivot,
+  };
+}
+
+/**
+ * Solve the linkage at a given shock stroke. `tracker` carries the previous
+ * step's positions so the continuous solution branch is selected; the returned
+ * tracker should be fed into the next call.
+ */
+export function solveFourBarAtStroke(
+  shockStroke: number,
+  geometry: BikeGeometry,
+  rig: FourBarRig,
+  tracker: FourBarTracker,
+): { solution: FourBarSolution; tracker: FourBarTracker } {
+  const rearWheelRadius = computedProperties.rearWheelRadius(geometry);
+  const currentShockLength = rig.topOutShockLength - shockStroke;
+
+  // 1. Rocker: shock eye lies on circle(R, shockArm) ∩ circle(F, shockLength).
+  const eyeCandidates = circleCircleIntersection(
+    rig.rockerPivot,
+    rig.rockerShockArm,
+    rig.frameMount,
+    currentShockLength,
+  );
+  const shockEye = nearest(eyeCandidates, tracker.shockEye);
+
+  if (!shockEye) {
+    // Linkage cannot reach this stroke — hold the previous position.
+    return { solution: trackerToSolution(geometry, rig, tracker, currentShockLength), tracker };
+  }
+
+  // 2. Rotate the rocker by the angle the shock eye swept, moving the upper
+  //    seatstay junction with it.
+  const rockerRotation =
+    angle(rig.rockerPivot, shockEye) - angle(rig.rockerPivot, rig.shockEye0);
+  const seatstayUpper = rotate(rig.seatstayUpper0, rig.rockerPivot, rockerRotation);
+
+  // 3. Seatstay: lower junction lies on circle(P, chainstayLen) ∩ circle(Ju, seatstayLen).
+  const lowerCandidates = circleCircleIntersection(
+    rig.mainPivot,
+    rig.chainstayLength,
+    seatstayUpper,
+    rig.seatstayLength,
+  );
+  const seatstayLower = nearest(lowerCandidates, tracker.seatstayLower);
+
+  if (!seatstayLower) {
+    return { solution: trackerToSolution(geometry, rig, tracker, currentShockLength), tracker };
+  }
+
+  // 4. Rear axle is rigid with the seatstay (Jl, Ju, A).
+  const axle = transformPointByReferenceLine(
+    rig.seatstayLower0,
+    rig.seatstayUpper0,
+    rig.axle0,
+    seatstayLower,
+    seatstayUpper,
+  );
+
+  // 5. Instant centre: chainstay line ∩ rocker-seatstay line.
+  const instantCenter =
+    lineIntersection(rig.mainPivot, seatstayLower, rig.rockerPivot, seatstayUpper) ??
+    tracker.instantCenter;
+
+  // Drop the whole frame so the rear axle sits on the ground (matches the
+  // single-pivot display convention).
+  const groundOffset = axle.y - rearWheelRadius;
+  const shift = (p: Point2D): Point2D => ({ x: p.x, y: p.y - groundOffset });
+
+  const solution: FourBarSolution = {
+    bbPosition: { x: 0, y: geometry.bbHeight - groundOffset },
+    rearAxlePosition: { x: axle.x, y: rearWheelRadius },
+    instantCenter: shift(instantCenter),
+    shockEyePosition: shift(shockEye),
+    mainPivot: shift(rig.mainPivot),
+    rockerPivot: shift(rig.rockerPivot),
+    seatstayLower: shift(seatstayLower),
+    seatstayUpper: shift(seatstayUpper),
+    shockLength: currentShockLength,
+    travelMM: Math.abs(groundOffset),
+  };
+
+  return {
+    solution,
+    tracker: { shockEye, seatstayLower, seatstayUpper, instantCenter },
+  };
+}
+
+function trackerToSolution(
+  geometry: BikeGeometry,
+  rig: FourBarRig,
+  tracker: FourBarTracker,
+  shockLength: number,
+): FourBarSolution {
+  const rearWheelRadius = computedProperties.rearWheelRadius(geometry);
+  const axle = transformPointByReferenceLine(
+    rig.seatstayLower0,
+    rig.seatstayUpper0,
+    rig.axle0,
+    tracker.seatstayLower,
+    tracker.seatstayUpper,
+  );
+  const groundOffset = axle.y - rearWheelRadius;
+  const shift = (p: Point2D): Point2D => ({ x: p.x, y: p.y - groundOffset });
+  return {
+    bbPosition: { x: 0, y: geometry.bbHeight - groundOffset },
+    rearAxlePosition: { x: axle.x, y: rearWheelRadius },
+    instantCenter: shift(tracker.instantCenter),
+    shockEyePosition: shift(tracker.shockEye),
+    mainPivot: shift(rig.mainPivot),
+    rockerPivot: shift(rig.rockerPivot),
+    seatstayLower: shift(tracker.seatstayLower),
+    seatstayUpper: shift(tracker.seatstayUpper),
+    shockLength,
+    travelMM: Math.abs(groundOffset),
+  };
+}

--- a/lib/kinematics.ts
+++ b/lib/kinematics.ts
@@ -129,6 +129,7 @@ export function runKinematicAnalysis(
     firstPassStates[0].pivotPosition,
     firstPassStates[0].rearAxlePosition,
     geometry,
+    seatstayReferenceFromFp(firstPassStates[0]),
   );
   const chainringRadius = sprocketRadius(geometry.chainringTeeth);
 
@@ -190,6 +191,7 @@ export function runKinematicAnalysis(
 
     const wheelRate = geometry.shockSpringRate / (leverageRatio * leverageRatio);
 
+    const seatstayRef = seatstayReferenceFromFp(fp);
     const antiSquat = calculateVisualAntiSquat(fp, frontAxlePos, geometry, applyPitchRotation);
     const antiRise = calculateVisualAntiRise(fp, frontAxlePos, geometry, applyPitchRotation);
     const trail = computeTrail(fp, frontAxlePos, geometry, applyPitchRotation);
@@ -221,6 +223,7 @@ export function runKinematicAnalysis(
       fp.pivotPosition,
       fp.rearAxlePosition,
       geometry,
+      seatstayRef,
     );
     const centreOfMassWorld: Point2D = {
       x: fp.bbPosition.x + geometry.comX,
@@ -232,6 +235,7 @@ export function runKinematicAnalysis(
       fp.pivotPosition,
       fp.rearAxlePosition,
       geometry,
+      seatstayRef,
     );
     const chainGrowth = (currentChainLength - referenceChainLength) / 2;
     const totalChainGrowth = chainGrowth;
@@ -524,13 +528,23 @@ function calculateStateAtShockStroke(
   };
 }
 
+// A rigid rear body used to carry a swingarm/seatstay-mounted idler, given by
+// two of its points in both top-out and current configurations.
+type SwingarmReference = { lower: Point2D; upper: Point2D } | null;
+
 // Internal helper: resolves idler position from raw world-frame points.
 // Used both during KinematicState construction and via the public getIdlerPosition.
+//
+// For a swingarm-mounted idler the idler is rigidly attached to the rear body:
+//   - Single pivot: that body is the swingarm (pivot → axle reference line).
+//   - Four bar:     that body is the seatstay (lower → upper junction reference
+//                   line); pass its current points via `seatstay`.
 function idlerPositionFromWorld(
   bbPos: Point2D,
   pivotPos: Point2D,
   rearAxlePos: Point2D,
   geometry: BikeGeometry,
+  seatstay: SwingarmReference = null,
 ): Point2D | null {
   if (geometry.idlerType === IdlerType.None) {
     return null;
@@ -538,11 +552,34 @@ function idlerPositionFromWorld(
     return Point2D.add(bbPos, { x: geometry.idlerX, y: geometry.idlerY });
   } else {
     // Swingarm-mounted idler
-    const rearWheelRadius = computedProperties.rearWheelRadius(geometry);
     const topOutIdler = {
       x: geometry.idlerX,
       y: geometry.bbHeight + geometry.idlerY,
     };
+
+    if (geometry.suspensionType === SuspensionType.FourBar && seatstay) {
+      // Four bar: the seatstay carries the rear axle, so the idler rides with
+      // it. Use the seatstay's own lower→upper junction line as the rigid
+      // reference (long, numerically stable baseline).
+      const topOutLower = {
+        x: geometry.seatstayLowerX,
+        y: geometry.bbHeight + geometry.seatstayLowerY,
+      };
+      const topOutUpper = {
+        x: geometry.rockerSeatstayX,
+        y: geometry.bbHeight + geometry.rockerSeatstayY,
+      };
+      return transformPointByReferenceLine(
+        topOutLower,
+        topOutUpper,
+        topOutIdler,
+        seatstay.lower,
+        seatstay.upper,
+      );
+    }
+
+    // Single pivot: idler is fixed to the swingarm (pivot → axle reference).
+    const rearWheelRadius = computedProperties.rearWheelRadius(geometry);
     const topOutPivot = {
       x: geometry.bbToPivotX,
       y: geometry.bbHeight + geometry.bbToPivotY,
@@ -575,21 +612,43 @@ export const getIdlerPosition = (
     state.pivot.world,
     state.rearAxle.world,
     geometry,
+    seatstayReferenceFromState(state),
   );
 };
+
+// Extracts the seatstay reference (world frame) from a state, or null when the
+// state has no four-bar linkage.
+function seatstayReferenceFromState(
+  state: KinematicState | BikeState,
+): SwingarmReference {
+  const fourBar = "fourBar" in state ? state.fourBar : null;
+  if (!fourBar) return null;
+  return {
+    lower: fourBar.seatstayLower.world,
+    upper: fourBar.seatstayUpper.world,
+  };
+}
+
+// Same as above, for the internal first-pass state.
+function seatstayReferenceFromFp(fp: FirstPassState): SwingarmReference {
+  return fp.fourBar
+    ? { lower: fp.fourBar.seatstayLower, upper: fp.fourBar.seatstayUpper }
+    : null;
+}
 
 function getFrontSprocketCircle(
   bbPos: Point2D,
   pivotPos: Point2D,
   rearAxlePos: Point2D,
   geometry: BikeGeometry,
+  seatstay: SwingarmReference,
 ): Circle {
   if (geometry.idlerType === IdlerType.FrameMounted) {
     // The chainring→idler segment is frame-fixed and does not apply force to the
     // swingarm.  The idler acts as the effective "front" of the driving segment
     // (idler → rear cog) that determines anti-squat.
     const radius = sprocketRadius(geometry.idlerTeeth);
-    const center = idlerPositionFromWorld(bbPos, pivotPos, rearAxlePos, geometry)!;
+    const center = idlerPositionFromWorld(bbPos, pivotPos, rearAxlePos, geometry, seatstay)!;
     return { center, radius };
   } else {
     // No idler: chainring → rear cog.
@@ -609,6 +668,7 @@ function getRearSprocketCircle(
   pivotPos: Point2D,
   rearAxlePos: Point2D,
   geometry: BikeGeometry,
+  seatstay: SwingarmReference,
 ): Circle {
   if (
     geometry.idlerType === IdlerType.None ||
@@ -616,7 +676,7 @@ function getRearSprocketCircle(
   ) {
     return { center: rearAxlePos, radius: sprocketRadius(geometry.cogTeeth) };
   } else {
-    const center = idlerPositionFromWorld(bbPos, pivotPos, rearAxlePos, geometry)!;
+    const center = idlerPositionFromWorld(bbPos, pivotPos, rearAxlePos, geometry, seatstay)!;
     return { center, radius: sprocketRadius(geometry.idlerTeeth) };
   }
 }
@@ -630,6 +690,7 @@ function calculateDrivetrainChainLength(
   pivotPos: Point2D,
   rearAxlePos: Point2D,
   geometry: BikeGeometry,
+  seatstay: SwingarmReference,
 ): number {
   const chainringCenter: Point2D = {
     x: bbPos.x + geometry.chainringOffsetX,
@@ -642,7 +703,7 @@ function calculateDrivetrainChainLength(
     return calculateChainLength(chainringCenter, rearAxlePos, chainringRadius, cogRadius);
   }
 
-  const idlerPos = idlerPositionFromWorld(bbPos, pivotPos, rearAxlePos, geometry)!;
+  const idlerPos = idlerPositionFromWorld(bbPos, pivotPos, rearAxlePos, geometry, seatstay)!;
   const idlerRadius = sprocketRadius(geometry.idlerTeeth);
 
   if (geometry.idlerType === IdlerType.FrameMounted) {
@@ -774,16 +835,17 @@ function computeAntiSquatSteps(
   frontAxlePos: Point2D,
   applyPitchRotation: (p: Point2D) => Point2D,
   geometry: BikeGeometry,
+  seatstay: SwingarmReference,
   opts: { sprocketTangent?: boolean; warn?: boolean } = {},
 ): AntiSquatCalculations {
   const { sprocketTangent = true, warn = false } = opts;
 
-  const frontSprocket = getFrontSprocketCircle(bbPos, pivotPos, rearAxlePos, geometry);
+  const frontSprocket = getFrontSprocketCircle(bbPos, pivotPos, rearAxlePos, geometry, seatstay);
   const frontSprocketRotated = {
     center: applyPitchRotation(frontSprocket.center),
     radius: frontSprocket.radius,
   };
-  const rearSprocket = getRearSprocketCircle(bbPos, pivotPos, rearAxlePos, geometry);
+  const rearSprocket = getRearSprocketCircle(bbPos, pivotPos, rearAxlePos, geometry, seatstay);
   const rearSprocketRotated = {
     center: applyPitchRotation(rearSprocket.center),
     radius: rearSprocket.radius,
@@ -867,6 +929,7 @@ export const doAntiSquatCalculations = (
     state.frontAxle.world,
     applyPitchRotation,
     geometry,
+    seatstayReferenceFromState(state),
     opts,
   );
 };
@@ -933,6 +996,7 @@ function calculateVisualAntiSquat(
     frontAxlePos,
     applyPitchRotation,
     geometry,
+    seatstayReferenceFromFp(fp),
     opts,
   );
   if (!("antiSquatIntersection" in calculations)) return 0;

--- a/lib/kinematics.ts
+++ b/lib/kinematics.ts
@@ -10,7 +10,14 @@ import {
   Circle,
   IdlerType,
   LineSegment,
+  SuspensionType,
 } from "./types";
+import {
+  establishFourBar,
+  solveFourBarAtStroke,
+  initialTracker,
+  FourBarTracker,
+} from "./fourbar";
 import {
   distance,
   angle,
@@ -37,10 +44,17 @@ interface FirstPassState {
   travelMM: number;
   rearAxlePosition: Point2D;
   bbPosition: Point2D;
-  pivotPosition: Point2D;
-  swingarmEyePosition: Point2D;
+  pivotPosition: Point2D; // single pivot: physical pivot; four-bar: instant centre
+  swingarmEyePosition: Point2D; // single pivot: shock eye on swingarm; four-bar: shock eye on rocker
   shockLength: number;
   proportionalForkStroke: number;
+  // Extra linkage points for four-bar bikes (world frame), null otherwise.
+  fourBar: {
+    mainPivot: Point2D;
+    rockerPivot: Point2D;
+    seatstayLower: Point2D;
+    seatstayUpper: Point2D;
+  } | null;
 }
 
 /**
@@ -56,7 +70,12 @@ export function runKinematicAnalysis(
   geometry: BikeGeometry,
   fixedForkCompressionMM?: number,
 ): AnalysisResults {
-  const rigidTriangle = establishRigidTriangle(geometry);
+  const isFourBar = geometry.suspensionType === SuspensionType.FourBar;
+  const rigidTriangle = isFourBar ? null : establishRigidTriangle(geometry);
+  const fourBarRig = isFourBar ? establishFourBar(geometry) : null;
+  let tracker: FourBarTracker | null = fourBarRig
+    ? initialTracker(fourBarRig)
+    : null;
 
   const stepSize = 0.5; // mm - finer steps for smoother graphs
   const strokeSteps = Math.floor(geometry.shockStroke / stepSize) + 1;
@@ -70,8 +89,34 @@ export function runKinematicAnalysis(
       fixedForkCompressionMM !== undefined
         ? fixedForkCompressionMM
         : travelRatio * geometry.forkTravel;
-    const state = calculateStateAtShockStroke(shockStroke, geometry, rigidTriangle);
-    firstPassStates.push({ ...state, proportionalForkStroke });
+
+    if (fourBarRig && tracker) {
+      const { solution, tracker: next } = solveFourBarAtStroke(
+        shockStroke,
+        geometry,
+        fourBarRig,
+        tracker,
+      );
+      tracker = next;
+      firstPassStates.push({
+        travelMM: solution.travelMM,
+        rearAxlePosition: solution.rearAxlePosition,
+        bbPosition: solution.bbPosition,
+        pivotPosition: solution.instantCenter,
+        swingarmEyePosition: solution.shockEyePosition,
+        shockLength: solution.shockLength,
+        proportionalForkStroke,
+        fourBar: {
+          mainPivot: solution.mainPivot,
+          rockerPivot: solution.rockerPivot,
+          seatstayLower: solution.seatstayLower,
+          seatstayUpper: solution.seatstayUpper,
+        },
+      });
+    } else {
+      const state = calculateStateAtShockStroke(shockStroke, geometry, rigidTriangle!);
+      firstPassStates.push({ ...state, proportionalForkStroke, fourBar: null });
+    }
   }
 
   // Second pass: build full BikeState with no dummy initialisation
@@ -220,6 +265,14 @@ export function runKinematicAnalysis(
       chainringCenter: toKP(chainringCenterWorld),
       idler: idlerWorld ? toKP(idlerWorld) : null,
       centreOfMass: toKP(centreOfMassWorld),
+      fourBar: fp.fourBar
+        ? {
+            mainPivot: toKP(fp.fourBar.mainPivot),
+            rockerPivot: toKP(fp.fourBar.rockerPivot),
+            seatstayLower: toKP(fp.fourBar.seatstayLower),
+            seatstayUpper: toKP(fp.fourBar.seatstayUpper),
+          }
+        : null,
     };
 
     states.push(state);
@@ -388,7 +441,7 @@ function calculateStateAtShockStroke(
   shockStroke: number,
   geometry: BikeGeometry,
   rigidTriangle: RigidTriangle,
-): Omit<FirstPassState, "proportionalForkStroke"> {
+): Omit<FirstPassState, "proportionalForkStroke" | "fourBar"> {
   const rearWheelRadius = computedProperties.rearWheelRadius(geometry);
 
   const eyeToAxleDistance = rigidTriangle.eyeToAxle;
@@ -674,6 +727,14 @@ export function overrideForkCompression(
     chainringCenter: toKP(state.chainringCenter.world),
     idler: state.idler ? toKP(state.idler.world) : null,
     centreOfMass: toKP(state.centreOfMass.world),
+    fourBar: state.fourBar
+      ? {
+          mainPivot: toKP(state.fourBar.mainPivot.world),
+          rockerPivot: toKP(state.fourBar.rockerPivot.world),
+          seatstayLower: toKP(state.fourBar.seatstayLower.world),
+          seatstayUpper: toKP(state.fourBar.seatstayUpper.world),
+        }
+      : null,
   };
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -48,7 +48,15 @@ export enum IdlerType {
   SwingarmMounted = "Swingarm Mounted",
 }
 
+export enum SuspensionType {
+  SinglePivot = "Single Pivot",
+  FourBar = "Four Bar",
+}
+
 export interface BikeGeometry {
+  // Suspension layout
+  suspensionType: SuspensionType;
+
   // Frame - Primary Inputs
   bbHeight: number; // mm from ground
   stack: number; // mm
@@ -63,9 +71,25 @@ export interface BikeGeometry {
   forkLength: number; // mm (axle to crown)
   forkOffset: number; // mm (rake)
 
-  // Suspension
+  // Suspension (single pivot)
   totalTravel: number; // mm
   swingarmLength: number; // mm (pivot to rear axle)
+
+  // Four-bar linkage (top-out positions, mm from BB)
+  // The linkage is defined by the resting (top-out) positions of each joint.
+  // Fixed lengths and rigid-body relationships are derived from these once.
+  lowerLinkPivotX: number; // main / chainstay pivot on frame
+  lowerLinkPivotY: number;
+  rockerPivotX: number; // rocker pivot on frame
+  rockerPivotY: number;
+  rockerShockMountX: number; // shock eye on rocker (moving shock mount)
+  rockerShockMountY: number;
+  rockerSeatstayX: number; // upper seatstay junction (on rocker)
+  rockerSeatstayY: number;
+  seatstayLowerX: number; // lower seatstay junction (on chainstay, the "Horst" pivot)
+  seatstayLowerY: number;
+  fourBarAxleX: number; // rear axle at top-out (carried by the seatstay)
+  fourBarAxleY: number;
 
   // Shock
   shockFrameMountX: number; // mm from BB
@@ -105,6 +129,7 @@ export function createDefaultGeometry({
   overrides,
 }: { overrides?: Partial<BikeGeometry> } = {}): BikeGeometry {
   return {
+    suspensionType: SuspensionType.SinglePivot,
     bbHeight: 330.0,
     stack: 625.0,
     reach: 490.0,
@@ -117,6 +142,20 @@ export function createDefaultGeometry({
     forkOffset: 44.0,
     totalTravel: 150.0,
     swingarmLength: 440.0,
+    // Four-bar default linkage (top-out positions relative to BB; BB world ≈ (0, 330)).
+    // Tuned for ~150 mm rear travel with a progressive leverage ratio (~2.2–2.6).
+    lowerLinkPivotX: -30.0,
+    lowerLinkPivotY: 20.0,
+    rockerPivotX: -20.0,
+    rockerPivotY: 230.0,
+    rockerShockMountX: 25.0,
+    rockerShockMountY: 260.0,
+    rockerSeatstayX: -90.0,
+    rockerSeatstayY: 260.0,
+    seatstayLowerX: -435.0,
+    seatstayLowerY: 10.0,
+    fourBarAxleX: -445.0,
+    fourBarAxleY: 45.0,
     shockFrameMountX: 30.0,
     shockFrameMountY: 70.0,
     shockSwingarmMountDistance: 190.0,
@@ -186,6 +225,18 @@ export interface BikeState extends KinematicState {
   chainringCenter: KinematicPoint;
   idler: KinematicPoint | null;
   centreOfMass: KinematicPoint;
+
+  // Four-bar linkage points (null for single-pivot bikes).
+  // For four-bar bikes `pivot` holds the (virtual) instant centre and
+  // `swingarmEye` holds the moving shock mount on the rocker.
+  fourBar: FourBarLinkagePoints | null;
+}
+
+export interface FourBarLinkagePoints {
+  mainPivot: KinematicPoint; // chainstay pivot on frame
+  rockerPivot: KinematicPoint; // rocker pivot on frame
+  seatstayLower: KinematicPoint; // chainstay ↔ seatstay junction
+  seatstayUpper: KinematicPoint; // seatstay ↔ rocker junction
 }
 
 export interface AnalysisResults {


### PR DESCRIPTION
Introduce a four-bar linkage option alongside the existing single-pivot
model. The linkage is defined by the top-out positions of its joints, from
which a new solver (lib/fourbar.ts) derives the fixed link lengths and
solves the single degree of freedom for each shock stroke:

- Shock drives the rocker (circle-circle intersection about the rocker
  pivot and frame mount).
- Rocker rotation carries the upper seatstay joint; the lower joint is
  solved from the chainstay and seatstay lengths.
- The rear axle rides rigidly on the seatstay; the rear-wheel instant
  centre is the intersection of the chainstay and rocker-seatstay lines
  and is stored as the effective pivot so anti-squat/anti-rise reuse the
  existing load-path analysis unchanged.

The kinematics engine branches on BikeGeometry.suspensionType; all
downstream metrics (leverage, pitch, chain growth, trail, etc.) are
shared. Default four-bar geometry is tuned for ~150 mm travel with a
progressive 2.2-2.6 leverage ratio.

UI:
- Suspension-type selector and a Four-Bar Linkage input section in the
  main panel (single-pivot-only fields are hidden for four-bar).
- New /linkage page reuses the same kinematics and rendering to show just
  the linkage, instant centre, shock and axle path, with its own
  compression slider and graphs.
- Linkage rendering component shared between the full-bike view and the
  inspector.

Adds lib/fourbar.test.ts covering rigid-body invariants, instant-centre
correctness, travel range, monotonicity and metric finiteness.